### PR TITLE
Fix ruby nokogiri

### DIFF
--- a/sources/install.sh
+++ b/sources/install.sh
@@ -2552,7 +2552,7 @@ function install_wpscan(){
   apt-get install -y apt-transport-https ca-certificates gnupg2 curl
   curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import -
   curl -sSL https://get.rvm.io | bash -s stable --ruby
-  gem install nokogiri
+  gem install nokogiri -v 1.11.4 -- --use-system-libraries # use this version to resolve the conflict with cewl 
   gem install wpscan
   add-history wpscan
   add-test-command "wpscan --help"
@@ -2812,6 +2812,7 @@ function install_cewl() {
   colorecho "Installing cewl"
   fapt cewl
   add-history cewl
+  add-test-command "cewl --help"
 }
 
 function install_curl() {
@@ -3392,7 +3393,7 @@ function package_wordlists() {
   install_crunch                  # Wordlist generator
   install_seclists                # Awesome wordlists
   install_rockyou                 # Basically installs rockyou (~same as Kali)
-  # install_cewl                  # Wordlist generator FIXME
+  install_cewl                    # Wordlist generator
   install_cupp                    # User password profiler
   install_pass_station            # Default credentials database
   install_username-anarchy        # Generate possible usernames based on heuristics


### PR DESCRIPTION
# Description
The installed version of Ruby Nokogiri is in conflict between wpscan and cewl, version 1.11.4 corresponds to both requirements. So I uncomment the installation of cewl , add test for cewl and change the installed version of nokogiri.

Conflict: 
![image](https://user-images.githubusercontent.com/34021743/220667518-e71e087b-f985-4dba-b3b0-97e338da2dbc.png)

The fix :
![image](https://user-images.githubusercontent.com/34021743/220667625-b9640fd6-1d0c-464f-a787-5434f7e9a8f3.png)

This may break other tools, I will see on the pipeline if this case happen.
