### PR TITLE
Add Netdiscover Tool

### DIFF
--- a/sources/install.sh
+++ b/sources/install.sh
@@ -2782,6 +2782,13 @@ function install_nmap() {
   add-test-command "nmap --version"
 }
 
+function install_netdiscover() {
+  colorecho "Installing netdiscover"
+  fapt netdiscover
+  add-history netdiscover
+  add-test-command "netdiscover -h |& grep 'Usage: netdiscover'"
+}
+
 function install_php() {
   colorecho "Installing php"
   fapt php
@@ -3733,6 +3740,7 @@ function package_network() {
   install_hping3                  # Discovery tool
   install_masscan                 # Port scanner
   install_nmap                    # Port scanner
+  install_netdiscover             # Active/passive address reconnaissance tool
   install_autorecon               # External recon tool
   install_tcpdump                 # Capture TCP traffic
   install_dnschef                 # Python DNS server

--- a/sources/zsh/history.d/netdiscover
+++ b/sources/zsh/history.d/netdiscover
@@ -1,0 +1,2 @@
+netdiscover -p
+netdiscover -i "$INTERFACE" -r 192.168.1.0/24


### PR DESCRIPTION
# Description
`Netdiscover is an active/passive address reconnaissance tool, mainly developed for those wireless networks without dhcp server, when you are wardriving. It can be also used on hub/switched networks.`
https://www.kali.org/tools/netdiscover/

This tool allows the user to passively scan the network by listening for ARP frames.
It can also act actively by sending ARP packages to private IP ranges.

The output is a nice table showing the IP / Mac address and MAC Vendor of the identified hosts. 
