### PR TITLE
Fix CrackMapExec broken install - Rustc - Cargo PATH

### DIFF
--- a/sources/install.sh
+++ b/sources/install.sh
@@ -427,6 +427,8 @@ function install_bolt() {
 
 function install_crackmapexec() {
   colorecho "Installing CrackMapExec"
+  # Source bc cme needs cargo PATH (rustc) -> aardwolf dep
+  source /root/.zshrc
   git -C /opt/tools/ clone https://github.com/Porchetta-Industries/CrackMapExec.git
   python3 -m pipx install /opt/tools/CrackMapExec/
   mkdir -p ~/.cme

--- a/sources/install.sh
+++ b/sources/install.sh
@@ -428,6 +428,7 @@ function install_bolt() {
 function install_crackmapexec() {
   colorecho "Installing CrackMapExec"
   # Source bc cme needs cargo PATH (rustc) -> aardwolf dep
+  # TODO: Optimize so that the PATH is always up to date
   source /root/.zshrc
   git -C /opt/tools/ clone https://github.com/Porchetta-Industries/CrackMapExec.git
   python3 -m pipx install /opt/tools/CrackMapExec/


### PR DESCRIPTION
# Description

The `cargo path` was missing in the `PATH` variable during `CrackMapExec` install. `Aardwolf` dependency needs it for its installation.

# Related issues

https://github.com/ThePorgs/Exegol-images/actions/runs/4335532241

# Related PR

https://github.com/ThePorgs/Exegol-images/pull/112