### PR TITLE
Fixed Firefox customization issue and added support for addons in my-resources

### DIFF
--- a/sources/exegol/load_supported_setups.sh
+++ b/sources/exegol/load_supported_setups.sh
@@ -107,14 +107,19 @@ function run_user_setup() {
 }
 
 function deploy_firefox_addons() {
+  ##### firefox custom addons deployment
   if [ -d "$MY_Setup_PATH/firefox/" ]; then
     if [ -d "$MY_Setup_PATH/firefox/addons" ]; then
       ADDON_FOLDER="-D $MY_Setup_PATH/firefox/addons"
+    else
+      mkdir "$MY_Setup_PATH/firefox/addons" && chmod 770 "$MY_Setup_PATH/firefox/addons"
     fi
     if [ -f "$MY_Setup_PATH/firefox/addons.txt" ]; then
       ADDON_LIST="-L $MY_Setup_PATH/firefox/addons.txt"
     fi
     python3 /opt/tools/firefox/user-setup.py $ADDON_LIST $ADDON_FOLDER
+  else
+    mkdir --parents "$MY_Setup_PATH/firefox/addons" && chmod 770 -R "$MY_Setup_PATH/firefox/addons"
   fi
 }
 

--- a/sources/exegol/load_supported_setups.sh
+++ b/sources/exegol/load_supported_setups.sh
@@ -122,6 +122,7 @@ function deploy_firefox_addons() {
     python3 /opt/tools/firefox/user-setup.py $ADDON_LIST $ADDON_FOLDER
   else
     mkdir --parents "$MY_Setup_PATH/firefox/addons" && chmod 770 -R "$MY_Setup_PATH/firefox/addons"
+    cp --preserve=mode /.exegol/skel/firefox/addons.txt "$MY_Setup_PATH/firefox/addons.txt"
   fi
 }
 

--- a/sources/exegol/load_supported_setups.sh
+++ b/sources/exegol/load_supported_setups.sh
@@ -106,6 +106,18 @@ function run_user_setup() {
   echo "[$(date +'%d-%m-%Y_%H-%M-%S')] ==== End of custom setups loading ===="
 }
 
+function deploy_firefox_addons() {
+  if [ -d "$MY_Setup_PATH/firefox/" ]; then
+    if [ -d "$MY_Setup_PATH/firefox/addons" ]; then
+      ADDON_FOLDER="-D $MY_Setup_PATH/firefox/addons"
+    fi
+    if [ -f "$MY_Setup_PATH/firefox/addons.txt" ]; then
+      ADDON_LIST="-L $MY_Setup_PATH/firefox/addons.txt"
+    fi
+    python3 /opt/tools/firefox/user-setup.py $ADDON_LIST $ADDON_FOLDER
+  fi
+}
+
 # Starting
 # This procedure is supposed to be executed only once at the first startup, using a lockfile check
 
@@ -124,7 +136,10 @@ deploy_tmux
 deploy_vim
 deploy_apt
 deploy_python3
+deploy_firefox_addons
 
 run_user_setup
 
 exit 0
+
+}

--- a/sources/exegol/load_supported_setups.sh
+++ b/sources/exegol/load_supported_setups.sh
@@ -116,6 +116,8 @@ function deploy_firefox_addons() {
     fi
     if [ -f "$MY_Setup_PATH/firefox/addons.txt" ]; then
       ADDON_LIST="-L $MY_Setup_PATH/firefox/addons.txt"
+    else
+      cp --preserve=mode /.exegol/skel/firefox/addons.txt "$MY_Setup_PATH/firefox/addons.txt"
     fi
     python3 /opt/tools/firefox/user-setup.py $ADDON_LIST $ADDON_FOLDER
   else
@@ -146,5 +148,3 @@ deploy_firefox_addons
 run_user_setup
 
 exit 0
-
-}

--- a/sources/exegol/skel/firefox/addons.txt
+++ b/sources/exegol/skel/firefox/addons.txt
@@ -1,0 +1,3 @@
+# This file can be used to install addons on the Firefox instance of Exegol.
+# The download links of the addons to be installed can be listed in this file (ie: https://addons.mozilla.org/fr/firefox/addon/foxyproxy-standard/).
+# All addons listed below will be downloaded and installed automatically when creating a new Exegol container.

--- a/sources/firefox/requirements.txt
+++ b/sources/firefox/requirements.txt
@@ -1,1 +1,2 @@
 R2Log
+requests

--- a/sources/firefox/user-setup.py
+++ b/sources/firefox/user-setup.py
@@ -15,7 +15,7 @@ import subprocess
 import argparse
 
 PATHNAME = "/root/.mozilla/firefox/**.Exegol/"
-re_links = r'^https://addons\.mozilla\.org/fr/firefox/addon/[^/]+'
+re_links = r'^https://addons\.mozilla\.org/fr/firefox/addon/[^/]+/?$'
 
 def parse_args():
     arg_parser = argparse.ArgumentParser(description="Automatically installs addons from a list or folder containing .xpi files.")

--- a/sources/firefox/user-setup.py
+++ b/sources/firefox/user-setup.py
@@ -15,7 +15,7 @@ import subprocess
 import argparse
 
 PATHNAME = "/root/.mozilla/firefox/**.Exegol/"
-re_links = r'https://addons\.mozilla\.org/fr/firefox/addon/[^/]+'
+re_links = r'^https://addons\.mozilla\.org/fr/firefox/addon/[^/]+'
 
 def parse_args():
     arg_parser = argparse.ArgumentParser(description="Automatically installs addons from a list or folder containing .xpi files.")
@@ -52,7 +52,10 @@ if __name__ == "__main__":
                 logger.success(f"{addon_name} installed sucessfully\n")
                 addon_list.append((addon_id, addon_name[0:-4], False))
                 install_ok = True
+        if install_ok:
             logger.success("All addons from the list were installed sucessfully\n")
+        else:
+            logger.error("No addons were found in the list %s.\n" % addon_links)
 
     if addon_folder is not None:
         if glob(addon_folder + "/*.xpi"):
@@ -65,7 +68,7 @@ if __name__ == "__main__":
                 install_ok = True
             logger.success("All addons from the folder %s were installed sucessfully\n" % addon_folder)
         else:
-            logger.error("No addons were found in the folder %s." % addon_folder)
+            logger.error("No addons were found in the folder %s.\n" % addon_folder)
 
     if install_ok:
         # Run firefox to initialise profile

--- a/sources/firefox/user-setup.py
+++ b/sources/firefox/user-setup.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# -- coding: utf-8 --
+# File name          : user-setup.py
+# Author             : Skilo (@askilow - Alexis Marquois)
+# Date created       : 07 march 2023
+# Python Version     : 3.*
+
+from setup import get_link, download_addon, read_manifest, install_addons, activate_addons
+from R2Log import logger
+from pathlib import Path
+from glob import glob
+from time import sleep
+import re
+import subprocess
+import argparse
+
+PATHNAME = "/root/.mozilla/firefox/**.Exegol/"
+re_links = r'https://addons\.mozilla\.org/fr/firefox/addon/[^/]+'
+
+def parse_args():
+    arg_parser = argparse.ArgumentParser(description="Automatically installs addons from a list or folder containing .xpi files.")
+    arg_parser.add_argument('-L', dest="addon_links", help="txt document containing addon link (ie: https://addons.mozilla.org/fr/firefox/addon/duckduckgo-for-firefox).")
+    arg_parser.add_argument('-D', dest="addon_folder", help="Path to a folder containing .xpi files to install.")
+    args = arg_parser.parse_args()
+    return args
+
+if __name__ == "__main__":
+
+    args = parse_args()
+    addon_links = args.addon_links
+    addon_folder = args.addon_folder
+    install_ok = False
+
+    # Define a list containing all addons names and ids
+    addon_list = []
+
+    if addon_links is not None:
+        # Read the list input by the user
+        with open(addon_links, "r") as url_file:
+            urls = url_file.read().splitlines()
+
+        # Iterate through addons
+        for url in urls:
+            if re.findall(re_links, url):
+                # Make a request to the URL
+                link, addon_name = get_link(url)
+                # Download the addon
+                download_addon(link, addon_name)
+                # Read manifest.json in the archive
+                addon_id = read_manifest("/tmp/" + addon_name)
+                install_addons(addon_name, addon_id, "/tmp/")
+                logger.success(f"{addon_name} installed sucessfully\n")
+                addon_list.append((addon_id, addon_name[0:-4], False))
+                install_ok = True
+            logger.success("All addons from the list were installed sucessfully\n")
+
+    if addon_folder is not None:
+        if glob(addon_folder + "/*.xpi"):
+            for addon_path in glob(addon_folder + "/*.xpi"):
+                addon_name = addon_path.split("/")[-1]
+                addon_id = read_manifest(addon_path)
+                install_addons(addon_name, addon_id, addon_folder)
+                logger.success(f"{addon_name} installed sucessfully\n")
+                addon_list.append((addon_id, addon_name[0:-4], False))
+                install_ok = True
+            logger.success("All addons from the folder %s were installed sucessfully\n" % addon_folder)
+        else:
+            logger.error("No addons were found in the folder %s." % addon_folder)
+
+    if install_ok:
+        # Run firefox to initialise profile
+        logger.info("Initialising Firefox profile")
+        try:
+            p_firefox = subprocess.Popen(["firefox", "-P", "Exegol", "-headless"], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+            # Wait for firefox to be initialised
+            while not addon_list[0][0].encode() in subprocess.check_output(["cat", glob("%s" % PATHNAME)[0] + "/extensions.json"]):
+                sleep(0.5)
+            p_firefox.kill()
+            assert(Path(glob("%s" % PATHNAME)[0] + "/extensions.json").is_file())
+            logger.success("Firefox profile initialised sucessfully\n")
+        except:
+            logger.error("Could not initialise Firefox profile")
+            raise
+
+        # Activate all addons
+        activate_addons(addon_list)
+
+        # Remove backup file interfering with addons activation
+        logger.info("Removing backup file interfering with addons activation")
+        try:
+            Path(glob("%s" % PATHNAME)[0] + "/addonStartup.json.lz4").unlink()
+            logger.success("Backup file successfully removed\n")
+        except:
+            logger.error("Could not remove the backup file")
+            raise
+
+        # Restart firefox to apply modifications
+        logger.info("Restarting firefox to apply modifications")
+        try:
+            p_firefox = subprocess.Popen(["firefox", "-headless"], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+            # Wait for modifications to be applied
+            while not b'addonStartup.json.lz4' in subprocess.check_output(["ls", glob("%s" % PATHNAME)[0]]):
+                sleep(0.5)
+            p_firefox.kill()
+            logger.success("Modifications successfully applied")
+        except:
+            logger.error("Could not restart firefox")
+            raise
+    else:
+        logger.error("No addons were found.")

--- a/sources/install.sh
+++ b/sources/install.sh
@@ -3276,6 +3276,7 @@ function install_firefox() {
   python3 -m pip install -r /opt/tools/firefox/requirements.txt
   python3 /opt/tools/firefox/setup.py
   add-test-command "file /root/.mozilla/firefox/*.Exegol"
+  add-test-command "firefox --version"
 }
 
 # Package dedicated to the basic things the env needs

--- a/sources/install.sh
+++ b/sources/install.sh
@@ -3270,11 +3270,12 @@ function install_ctf-party() {
 
 function install_firefox() {
   colorecho "Installing firefox"
+  fapt firefox-esr
   mkdir /opt/tools/firefox
   mv /root/sources/firefox/* /opt/tools/firefox/
   python3 -m pip install -r /opt/tools/firefox/requirements.txt
   python3 /opt/tools/firefox/setup.py
-  add-test-command "firefox --version"
+  add-test-command "file /root/.mozilla/firefox/*.Exegol"
 }
 
 # Package dedicated to the basic things the env needs


### PR DESCRIPTION
Firefox customization now works as announced in PR #107. 🦊 
Also, the user is now able to add his favourites addons to each new container with my-resources by two ways.

### With a list
It is possible to create a list in ~/.exegol/my-resources/setup/firefox/addons.txt with the links in Mozilla's addon shop :
![image](https://user-images.githubusercontent.com/83423277/223792872-b826d165-e03a-49e8-ade0-0947652f6d89.png)

> The last versions of the addons will then be downloaded and installed automatically.

### With xpi files
It is also possible to directly add .xpi files in the folder ~/.exegol/my-resources/setup/firefox/addons :
![image](https://user-images.githubusercontent.com/83423277/223792945-60964efe-1739-4210-9330-f98854a0c886.png)

> The addons will then be installed from local .xpi files.

**Note** : both way can be used *simultaneously* by just creating the addons.txt and the addons folder.