### PR TITLE
Fix amass installation

### DIFF
--- a/sources/install.sh
+++ b/sources/install.sh
@@ -2521,7 +2521,7 @@ function install_rockyou(){
 function install_amass(){
   colorecho "Installing Amass"
   set_go_env
-  go install -v github.com/OWASP/Amass/v3/...@master
+  go install -v github.com/owasp-amass/amass/v3/...@master
   add-test-command "amass -version"
 }
 


### PR DESCRIPTION
# Description

The amass install URL seems to have changed from `github.com/OWASP/Amass/v3/...@master` to `github.com/owasp-amass/amass/v3/...@master`

# Related issues

https://github.com/ThePorgs/Exegol-images/actions/runs/4667149750/jobs/8270118394?pr=129

https://github.com/ThePorgs/Exegol-images/actions/runs/4682060823/jobs/8322882477?pr=135