### PR TITLE
Fix - trilium loading desktop.js resource

### DIFF
--- a/sources/assets/zsh/aliases.d/trilium
+++ b/sources/assets/zsh/aliases.d/trilium
@@ -1,2 +1,2 @@
-alias trilium-start='echo "Starting server on http://$(cat ~/.local/share/trilium-data/config.ini | grep host= | cut -d = -f 2):$(cat ~/.local/share/trilium-data/config.ini | grep port= | cut -d = -f 2)/" && nvm use 16 && nohup node /opt/tools/trilium/src/www &> ~/.trilium.nohup.out &'
+alias trilium-start='echo "Starting server on http://$(cat ~/.local/share/trilium-data/config.ini | grep host= | cut -d = -f 2):$(cat ~/.local/share/trilium-data/config.ini | grep port= | cut -d = -f 2)/" && nvm use 16 && TRILIUM_ENV=dev nohup node /opt/tools/trilium/src/www &> ~/.trilium.nohup.out &'
 alias trilium-stop='fuser -k $(cat ~/.local/share/trilium-data/config.ini | grep port= | cut -d = -f 2)/tcp'


### PR DESCRIPTION
# Description

Fixed trillium tool starting issue after authentication.

The environment variable `TRILIUM_ENV=dev` was missing in the alias.

# Related issues

Once logged in, the service fails to load the `desktop.js` resource.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/51704860/235638557-218298cc-59bb-446c-90b0-ec2433a1627e.png">

# Point of attention

On the official Trillium github repository, the tool is started with this environment variable :

https://github.com/zadam/trilium/blob/stable/package.json
