### PR TITLE
Reduce Docker images size by removing the folder .git for each tool

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -812,7 +812,7 @@ function install_ldeep() {
 
 function install_rusthound() {
     colorecho "Installing RustHound"
-    fapt gcc libclang-dev clang libclang-dev libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit musl-tools gcc-mingw-w64-x86-64
+    fapt gcc libclang-dev clang libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit musl-tools gcc-mingw-w64-x86-64
     git -C /opt/tools/ clone --depth 1 https://github.com/OPENCYBER-FR/RustHound
     rm -rf /opt/tools/RustHound/.git
     cd /opt/tools/RustHound

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -22,7 +22,8 @@ function install_ad_apt_tools() {
 
 function install_responder() {
     colorecho "Installing Responder"
-    git -C /opt/tools/ clone --depth=1 https://github.com/lgandx/Responder
+    git -C /opt/tools/ clone --depth 1 https://github.com/lgandx/Responder
+    rm -rf /opt/tools/Responder/.git
     add-aliases responder
     add-history responder
     add-test-command "responder --version"
@@ -72,7 +73,8 @@ function install_crackmapexec() {
     # Source bc cme needs cargo PATH (rustc) -> aardwolf dep
     # TODO: Optimize so that the PATH is always up to date
     source /root/.zshrc || true
-    git -C /opt/tools/ clone https://github.com/Porchetta-Industries/CrackMapExec.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/Porchetta-Industries/CrackMapExec.git
+    rm -rf /opt/tools/CrackMapExec/.git
     python3 -m pipx install /opt/tools/CrackMapExec/
     add-aliases crackmapexec
     add-history crackmapexec
@@ -86,7 +88,8 @@ function configure_crackmapexec() {
     [ -f ~/.cme/cme.conf ] && mv ~/.cme/cme.conf ~/.cme/cme.conf.bak
     cp -v /root/sources/assets/crackmapexec/cme.conf ~/.cme/cme.conf
     # below is for having the ability to check the source code when working with modules and so on
-    # git -C /opt/tools/ clone https://github.com/byt3bl33d3r/CrackMapExec
+    # git -C /opt/tools/ clone --depth 1 https://github.com/byt3bl33d3r/CrackMapExec
+    # rm -rf /opt/tools/CrackMapExec/.git
     cp -v /root/sources/assets/grc/conf.cme /usr/share/grc/conf.cme
 }
 
@@ -101,7 +104,8 @@ function install_bloodhound-py() {
 
 function install_bloodhound() {
     colorecho "Installing BloodHound from sources"
-    git -C /opt/tools/ clone --depth=1 https://github.com/BloodHoundAD/BloodHound/
+    git -C /opt/tools/ clone --depth 1 https://github.com/BloodHoundAD/BloodHound/
+    rm -rf /opt/tools/BloodHound/.git
     mv /opt/tools/BloodHound /opt/tools/BloodHound4
     zsh -c "source ~/.zshrc && cd /opt/tools/BloodHound4 && nvm install 16.13.0 && nvm use 16.13.0 && npm install -g electron-packager && npm install && npm run build:linux"
     add-history bloodhound
@@ -133,7 +137,8 @@ function configure_bloodhound() {
 
 function install_cypheroth() {
     colorecho "Installing cypheroth"
-    git -C /opt/tools/ clone --depth=1 https://github.com/seajaysec/cypheroth
+    git -C /opt/tools/ clone --depth 1 https://github.com/seajaysec/cypheroth
+    rm -rf /opt/tools/cypheroth/.git
     add-aliases cypheroth
     add-history cypheroth
     add-test-command "cypheroth --help|& grep 'Example with Defaults:'"
@@ -184,7 +189,8 @@ function configure_impacket() {
 
 function install_pykek() {
     colorecho "Installing Python Kernel Exploit Kit (pykek) for MS14-068"
-    git -C /opt/tools/ clone --depth=1 https://github.com/preempt/pykek
+    git -C /opt/tools/ clone --depth 1 https://github.com/preempt/pykek
+    rm -rf /opt/tools/pykek/.git
     add-aliases pykek
     add-test-command "ms14-068.py |& grep '<clearPassword>'"
     add-to-list "pykek,https://github.com/preempt/pykek,PyKEK (Python Kerberos Exploitation Kit), a python library to manipulate KRB5-related data."
@@ -200,7 +206,8 @@ function install_lsassy() {
 
 function install_privexchange() {
     colorecho "Installing privexchange"
-    git -C /opt/tools/ clone --depth=1 https://github.com/dirkjanm/PrivExchange
+    git -C /opt/tools/ clone --depth 1 https://github.com/dirkjanm/PrivExchange
+    rm -rf /opt/tools/PrivExchange/.git
     cd /opt/tools/PrivExchange
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
@@ -221,7 +228,8 @@ function install_ruler() {
 function install_darkarmour() {
     colorecho "Installing darkarmour"
     fapt mingw-w64-tools mingw-w64-common g++-mingw-w64 gcc-mingw-w64 upx-ucl osslsigncode
-    git -C /opt/tools/ clone --depth=1 https://github.com/bats3c/darkarmour
+    git -C /opt/tools/ clone --depth 1 https://github.com/bats3c/darkarmour
+    rm -rf /opt/tools/darkarmour/.git
     add-aliases darkarmour
     add-history darkarmour
     add-test-command "darkarmour --help"
@@ -231,7 +239,8 @@ function install_darkarmour() {
 function install_amber() {
     colorecho "Installing amber"
     # Installing keystone requirement
-    git -C /opt/tools/ clone --depth=1 https://github.com/EgeBalci/keystone
+    git -C /opt/tools/ clone --depth 1 https://github.com/EgeBalci/keystone
+    rm -rf /opt/tools/keystone/.git
     cd /opt/tools/keystone
     mkdir build && cd build
     ../make-lib.sh
@@ -275,7 +284,8 @@ function configure_powershell() {
 
 function install_krbrelayx() {
     colorecho "Installing krbrelayx"
-    git -C /opt/tools/ clone --depth=1 https://github.com/dirkjanm/krbrelayx
+    git -C /opt/tools/ clone --depth 1 https://github.com/dirkjanm/krbrelayx
+    rm -rf /opt/tools/krbrelayx/.git
     cd /opt/tools/krbrelayx
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install dnspython ldap3 impacket dsinternals
@@ -295,7 +305,8 @@ function configure_krbrelayx() {
 
 function install_evilwinrm() {
     colorecho "Installing evil-winrm"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Hackplayers/evil-winrm
+    git -C /opt/tools/ clone --depth 1 https://github.com/Hackplayers/evil-winrm
+    rm -rf /opt/tools/evil-winrm/.git
     cd /opt/tools/evil-winrm
     bundle install
     add-aliases evil-winrm
@@ -314,7 +325,8 @@ function install_pypykatz() {
 
 function install_enyx() {
     colorecho "Installing enyx"
-    git -C /opt/tools/ clone --depth=1 https://github.com/trickster0/Enyx
+    git -C /opt/tools/ clone --depth 1 https://github.com/trickster0/Enyx
+    rm -rf /opt/tools/Enyx/.git
     add-aliases enyx
     add-history enyx
     add-test-command "enyx"
@@ -335,8 +347,10 @@ function install_zerologon() {
     cd /opt/tools/zerologon
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
-    git -C /opt/tools/zerologon clone --depth=1 https://github.com/SecuraBV/CVE-2020-1472 zerologon-scan
-    git -C /opt/tools/zerologon clone --depth=1 https://github.com/dirkjanm/CVE-2020-1472 zerologon-exploit
+    git -C /opt/tools/zerologon clone --depth 1 https://github.com/SecuraBV/CVE-2020-1472 zerologon-scan
+    git -C /opt/tools/zerologon clone --depth 1 https://github.com/dirkjanm/CVE-2020-1472 zerologon-exploit
+    rm -rf /opt/tools/zerologon/zerologon-scan/.git
+    rm -rf /opt/tools/zerologon/zerologon-exploit/.git
     add-aliases zerologon
     add-history zerologon
     add-test-command "zerologon-scan| grep Usage"
@@ -345,7 +359,8 @@ function install_zerologon() {
 
 function install_libmspack() {
     colorecho "Installing libmspack"
-    git -C /opt/tools/ clone --depth=1 https://github.com/kyz/libmspack.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/kyz/libmspack.git
+    rm -rf /opt/tools/libmspack/.git
     cd /opt/tools/libmspack/libmspack
     ./rebuild.sh
     ./configure
@@ -358,11 +373,13 @@ function install_libmspack() {
 function install_windapsearch-go() {
     colorecho "Installing Go windapsearch"
     # Install mage dependency
-    git -C /opt/tools/ clone https://github.com/magefile/mage
+    git -C /opt/tools/ clone --depth 1 https://github.com/magefile/mage
+    rm -rf /opt/tools/mage/.git
     cd /opt/tools/mage
     go run bootstrap.go
     # Install windapsearch tool
-    git -C /opt/tools/ clone --depth=1 https://github.com/ropnop/go-windapsearch
+    git -C /opt/tools/ clone --depth 1 https://github.com/ropnop/go-windapsearch
+    rm -rf /opt/tools/go-windapsearch/.git
     cd /opt/tools/go-windapsearch
     /root/go/bin/mage build
     add-aliases windapsearch
@@ -386,7 +403,8 @@ function install_oaburl() {
 
 function install_lnkup() {
     colorecho "Installing LNKUp"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Plazmaz/LNKUp
+    git -C /opt/tools/ clone --depth 1 https://github.com/Plazmaz/LNKUp
+    rm -rf /opt/tools/LNKUp/.git
     cd /opt/tools/LNKUp
     virtualenv --python=/usr/bin/python2 ./venv
     ./venv/bin/python2 -m pip install -r requirements.txt
@@ -398,7 +416,8 @@ function install_lnkup() {
 
 function install_polenum() {
     colorecho "Installing polenum"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Wh1t3Fox/polenum
+    git -C /opt/tools/ clone --depth 1 https://github.com/Wh1t3Fox/polenum
+    rm -rf /opt/tools/polenum/.git
     cd /opt/tools/polenum
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install impacket
@@ -421,7 +440,8 @@ function install_pth-tools() {
     if [[ $(uname -m) = 'x86_64' ]]
     then
         fapt libreadline8 && ln -s /usr/lib/x86_64-linux-gnu/libreadline.so /usr/lib/x86_64-linux-gnu/libreadline.so.6
-        git -C /opt/tools clone --depth=1 https://github.com/byt3bl33d3r/pth-toolkit
+        git -C /opt/tools clone --depth 1 https://github.com/byt3bl33d3r/pth-toolkit
+        rm -rf /opt/tools/pth-toolkit/.git
         add-aliases pth-tools
         add-history pth-tools
         add-test-command "pth-net --version"
@@ -448,7 +468,8 @@ function install_smtp-user-enum() {
 
 function install_gpp-decrypt() {
     colorecho "Installing gpp-decrypt"
-    git -C /opt/tools/ clone --depth=1 https://github.com/t0thkr1s/gpp-decrypt
+    git -C /opt/tools/ clone --depth 1 https://github.com/t0thkr1s/gpp-decrypt
+    rm -rf /opt/tools/gpp-decrypt/.git
     cd /opt/tools/gpp-decrypt
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install pycrypto colorama
@@ -459,7 +480,8 @@ function install_gpp-decrypt() {
 
 function install_ntlmv1-multi() {
     colorecho "Installing ntlmv1 multi tool"
-    git -C /opt/tools clone --depth=1 https://github.com/evilmog/ntlmv1-multi
+    git -C /opt/tools clone --depth 1 https://github.com/evilmog/ntlmv1-multi
+    rm -rf /opt/tools/ntlmv1-multi/.git
     add-aliases ntlmv1-multi
     add-history ntlmv1-multi
     add-test-command "ntlmv1-multi --ntlmv1 a::a:a:a:a"
@@ -491,7 +513,8 @@ function install_adidnsdump() {
 
 function install_pygpoabuse() {
     colorecho "Installing pyGPOabuse"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Hackndo/pyGPOAbuse
+    git -C /opt/tools/ clone --depth 1 https://github.com/Hackndo/pyGPOAbuse
+    rm -rf /opt/tools/pyGPOAbuse/.git
     cd /opt/tools/pyGPOAbuse
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -510,7 +533,8 @@ function install_bloodhound-import() {
 
 function install_bloodhound-quickwin() {
     colorecho "Installing bloodhound-quickwin"
-    git -C /opt/tools/ clone --depth=1 https://github.com/kaluche/bloodhound-quickwin
+    git -C /opt/tools/ clone --depth 1 https://github.com/kaluche/bloodhound-quickwin
+    rm -rf /opt/tools/bloodhound-quickwin/.git
     cd /opt/tools/bloodhound-quickwin
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install py2neo pandas prettytable
@@ -522,7 +546,8 @@ function install_bloodhound-quickwin() {
 
 function install_ldapsearch-ad() {
     colorecho "Installing ldapsearch-ad"
-    git -C /opt/tools/ clone --depth=1 https://github.com/yaap7/ldapsearch-ad
+    git -C /opt/tools/ clone --depth 1 https://github.com/yaap7/ldapsearch-ad
+    rm -rf /opt/tools/ldapsearch-ad/.git
     cd /opt/tools/ldapsearch-ad
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -534,12 +559,14 @@ function install_ldapsearch-ad() {
 
 function install_petitpotam() {
     colorecho "Installing PetitPotam"
-    git -C /opt/tools/ clone --depth=1 https://github.com/ly4k/PetitPotam
+    git -C /opt/tools/ clone --depth 1 https://github.com/ly4k/PetitPotam
+    rm -rf /opt/tools/PetitPotam/.git
     cd /opt/tools/PetitPotam
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
     mv /opt/tools/PetitPotam /opt/tools/PetitPotam_alt
-    git -C /opt/tools/ clone --depth=1 https://github.com/topotam/PetitPotam
+    git -C /opt/tools/ clone --depth 1 https://github.com/topotam/PetitPotam
+    rm -rf /opt/tools/PetitPotam/.git
     cd /opt/tools/PetitPotam
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
@@ -551,7 +578,8 @@ function install_petitpotam() {
 
 function install_dfscoerce() {
     colorecho "Installing DfsCoerce"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Wh04m1001/DFSCoerce
+    git -C /opt/tools/ clone --depth 1 https://github.com/Wh04m1001/DFSCoerce
+    rm -rf /opt/tools/DFSCoerce/.git
     cd /opt/tools/DFSCoerce
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
@@ -571,7 +599,8 @@ function install_coercer() {
 
 function install_pkinittools() {
     colorecho "Installing PKINITtools"
-    git -C /opt/tools/ clone --depth=1 https://github.com/dirkjanm/PKINITtools
+    git -C /opt/tools/ clone --depth 1 https://github.com/dirkjanm/PKINITtools
+    rm -rf /opt/tools/PKINITtools/.git
     cd /opt/tools/PKINITtools
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -583,7 +612,8 @@ function install_pkinittools() {
 
 function install_pywhisker() {
     colorecho "Installing pyWhisker"
-    git -C /opt/tools/ clone --depth=1 https://github.com/ShutdownRepo/pywhisker
+    git -C /opt/tools/ clone --depth 1 https://github.com/ShutdownRepo/pywhisker
+    rm -rf /opt/tools/pywhisker/.git
     cd /opt/tools/pywhisker
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -595,7 +625,8 @@ function install_pywhisker() {
 
 function install_manspider() {
     colorecho "Installing Manspider"
-    git -C /opt/tools clone --depth=1 https://github.com/blacklanternsecurity/MANSPIDER.git
+    git -C /opt/tools clone --depth 1 https://github.com/blacklanternsecurity/MANSPIDER.git
+    rm -rf /opt/tools/MANSPIDER/.git
     cd /opt/tools/MANSPIDER
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install .
@@ -608,7 +639,8 @@ function install_manspider() {
 
 function install_targetedKerberoast() {
     colorecho "Installing targetedKerberoast"
-    git -C /opt/tools/ clone https://github.com/ShutdownRepo/targetedKerberoast
+    git -C /opt/tools/ clone --depth 1 https://github.com/ShutdownRepo/targetedKerberoast
+    rm -rf /opt/tools/targetedKerberoast/.git
     cd /opt/tools/targetedKerberoast
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -621,7 +653,8 @@ function install_targetedKerberoast() {
 function install_pcredz() {
     colorecho "Installing PCredz"
     fapt libpcap-dev
-    git -C /opt/tools/ clone --depth=1 https://github.com/lgandx/PCredz
+    git -C /opt/tools/ clone --depth 1 https://github.com/lgandx/PCredz
+    rm -rf /opt/tools/PCredz/.git
     cd /opt/tools/PCredz
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install Cython
@@ -633,7 +666,8 @@ function install_pcredz() {
 
 function install_pywsus() {
     colorecho "Installing pywsus"
-    git -C /opt/tools/ clone --depth=1 https://github.com/GoSecure/pywsus
+    git -C /opt/tools/ clone --depth 1 https://github.com/GoSecure/pywsus
+    rm -rf /opt/tools/pywsus/.git
     cd /opt/tools/pywsus
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r ./requirements.txt
@@ -645,7 +679,8 @@ function install_pywsus() {
 
 function install_donpapi() {
     colorecho "Installing DonPAPI"
-    git -C /opt/tools/ clone --depth=1 https://github.com/login-securite/DonPAPI.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/login-securite/DonPAPI.git
+    rm -rf /opt/tools/DonPAPI/.git
     cd /opt/tools/DonPAPI
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r ./requirements.txt
@@ -673,7 +708,8 @@ function install_certipy() {
 
 function install_shadowcoerce() {
     colorecho "Installing ShadowCoerce PoC"
-    git -C /opt/tools/ clone --depth=1 https://github.com/ShutdownRepo/ShadowCoerce
+    git -C /opt/tools/ clone --depth 1 https://github.com/ShutdownRepo/ShadowCoerce
+    rm -rf /opt/tools/ShadowCoerce/.git
     cd /opt/tools/ShadowCoerce
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
@@ -685,7 +721,8 @@ function install_shadowcoerce() {
 
 function install_gmsadumper() {
     colorecho "Installing gMSADumper"
-    git -C /opt/tools/ clone --depth=1 https://github.com/micahvandeusen/gMSADumper
+    git -C /opt/tools/ clone --depth 1 https://github.com/micahvandeusen/gMSADumper
+    rm -rf /opt/tools/gMSADumper/.git
     cd /opt/tools/gMSADumper
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -697,7 +734,8 @@ function install_gmsadumper() {
 
 function install_pylaps() {
     colorecho "Installing pyLAPS"
-    git -C /opt/tools/ clone --depth=1 https://github.com/p0dalirius/pyLAPS
+    git -C /opt/tools/ clone --depth 1 https://github.com/p0dalirius/pyLAPS
+    rm -rf /opt/tools/pyLAPS/.git
     cd /opt/tools/pyLAPS
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
@@ -709,7 +747,8 @@ function install_pylaps() {
 
 function install_finduncommonshares() {
     colorecho "Installing FindUncommonShares"
-    git -C /opt/tools/ clone --depth=1 https://github.com/p0dalirius/FindUncommonShares
+    git -C /opt/tools/ clone --depth 1 https://github.com/p0dalirius/FindUncommonShares
+    rm -rf /opt/tools/FindUncommonShares/.git
     cd /opt/tools/FindUncommonShares/
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -721,7 +760,8 @@ function install_finduncommonshares() {
 
 function install_ldaprelayscan() {
     colorecho "Installing LdapRelayScan"
-    git -C /opt/tools/ clone --depth=1 https://github.com/zyn3rgy/LdapRelayScan
+    git -C /opt/tools/ clone --depth 1 https://github.com/zyn3rgy/LdapRelayScan
+    rm -rf /opt/tools/LdapRelayScan/.git
     cd /opt/tools/LdapRelayScan
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -741,7 +781,8 @@ function install_goldencopy() {
 
 function install_crackhound() {
     colorecho "Installing CrackHound"
-    git -C /opt/tools/ clone --depth=1 https://github.com/trustedsec/CrackHound
+    git -C /opt/tools/ clone --depth 1 https://github.com/trustedsec/CrackHound
+    rm -rf /opt/tools/CrackHound/.git
     cd /opt/tools/CrackHound
     prs="6"
     for pr in $prs; do git fetch origin pull/$pr/head:pull/$pr && git merge --strategy-option theirs --no-edit pull/$pr; done
@@ -772,7 +813,8 @@ function install_ldeep() {
 function install_rusthound() {
     colorecho "Installing RustHound"
     fapt gcc libclang-dev clang libclang-dev libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit musl-tools gcc-mingw-w64-x86-64
-    git -C /opt/tools/ clone https://github.com/OPENCYBER-FR/RustHound
+    git -C /opt/tools/ clone --depth 1 https://github.com/OPENCYBER-FR/RustHound
+    rm -rf /opt/tools/RustHound/.git
     cd /opt/tools/RustHound
     # Sourcing rustup shell setup, so that rust binaries are found when installing cme
     source "$HOME/.cargo/env"
@@ -827,7 +869,8 @@ function install_roastinthemiddle() {
 
 function install_PassTheCert() {
     colorecho "Installing PassTheCert"
-    git -C /opt/tools/ clone --depth=1 https://github.com/AlmondOffSec/PassTheCert
+    git -C /opt/tools/ clone --depth 1 https://github.com/AlmondOffSec/PassTheCert
+    rm -rf /opt/tools/PassTheCert/.git
     cd /opt/tools/PassTheCert/Python/
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -11,7 +11,8 @@ function update() {
 
 function install_exegol-history() {
     colorecho "Installing Exegol-history"
-    #  git -C /opt/tools/ clone https://github.com/ThePorgs/Exegol-history
+    #  git -C /opt/tools/ clone --depth 1 https://github.com/ThePorgs/Exegol-history
+    #  rm -rf /opt/tools/Exegol-history/.git
     # todo : below is something basic. A nice tool being created for faster and smoother worflow
     mkdir -p /opt/tools/Exegol-history
     rm -rf /opt/tools/Exegol-history/profile.sh
@@ -118,11 +119,17 @@ function install_ohmyzsh() {
     colorecho "Installing oh-my-zsh, config, history, aliases"
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
     cp -v /root/sources/assets/zsh/zshrc ~/.zshrc
-    git -C ~/.oh-my-zsh/custom/plugins/ clone https://github.com/zsh-users/zsh-autosuggestions
-    git -C ~/.oh-my-zsh/custom/plugins/ clone https://github.com/zsh-users/zsh-syntax-highlighting
-    git -C ~/.oh-my-zsh/custom/plugins/ clone https://github.com/zsh-users/zsh-completions
-    git -C ~/.oh-my-zsh/custom/plugins/ clone https://github.com/agkozak/zsh-z
-    git -C ~/.oh-my-zsh/custom/plugins/ clone https://github.com/lukechilds/zsh-nvm
+    git -C ~/.oh-my-zsh/custom/plugins/ clone --depth 1 https://github.com/zsh-users/zsh-autosuggestions
+    git -C ~/.oh-my-zsh/custom/plugins/ clone --depth 1 https://github.com/zsh-users/zsh-syntax-highlighting
+    git -C ~/.oh-my-zsh/custom/plugins/ clone --depth 1 https://github.com/zsh-users/zsh-completions
+    git -C ~/.oh-my-zsh/custom/plugins/ clone --depth 1 https://github.com/agkozak/zsh-z
+    git -C ~/.oh-my-zsh/custom/plugins/ clone --depth 1 https://github.com/lukechilds/zsh-nvm
+    rm -rf ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions/.git
+    rm -rf ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting/.git
+    rm -rf ~/.oh-my-zsh/custom/plugins/zsh-completions/.git
+    rm -rf ~/.oh-my-zsh/custom/plugins/zsh-z/.git
+    rm -rf ~/.oh-my-zsh/custom/plugins/zsh-nvm/.git
+
     zsh -c "source ~/.oh-my-zsh/custom/plugins/zsh-nvm/zsh-nvm.plugin.zsh" # this is needed to start an instance of zsh to have the plugin set up
     add-aliases fzf
     add-test-command "fzf-wordlists --help"
@@ -149,7 +156,8 @@ function install_ultimate_vimrc() {
         return
     fi
     colorecho "Installing The Ultimate vimrc"
-    git clone --depth=1 https://github.com/amix/vimrc.git ~/.vim_runtime
+    git clone --depth 1 https://github.com/amix/vimrc.git ~/.vim_runtime
+    rm -rf ~/.vim_runtime/.git
     sh ~/.vim_runtime/install_awesome_vimrc.sh
 }
 
@@ -167,10 +175,10 @@ function install_gf() {
     echo 'source $GOPATH/pkg/mod/github.com/tomnomnom/gf@*/gf-completion.zsh' >> ~/.zshrc
     cp -r /root/go/pkg/mod/github.com/tomnomnom/gf@*/examples ~/.gf
     # Add patterns from 1ndianl33t
-    git -C /opt/tools/ clone --depth=1 https://github.com/1ndianl33t/Gf-Patterns
+    git -C /opt/tools/ clone --depth 1 https://github.com/1ndianl33t/Gf-Patterns
     cp -r /opt/tools/Gf-Patterns/*.json ~/.gf
     # Remove repo to save space
-    rm -r /opt/tools/Gf-Patterns
+    rm -rf /opt/tools/Gf-Patterns
     add-test-command "gf --list"
     add-test-command "ls ~/.gf | grep 'redirect.json'"
 }

--- a/sources/install/package_c2.sh
+++ b/sources/install/package_c2.sh
@@ -42,7 +42,8 @@ function install_routersploit() {
 
 function install_sliver() {
     colorecho "Installing Sliver"
-    git -C /opt/tools/ clone --depth=1 https://github.com/BishopFox/sliver.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/BishopFox/sliver.git
+    rm -rf /opt/tools/sliver/.git
     cd /opt/tools/sliver
     make
     cp sliver-* /opt/tools/bin

--- a/sources/install/package_code_analysis.sh
+++ b/sources/install/package_code_analysis.sh
@@ -5,7 +5,8 @@ source common.sh
 
 function install_vulny-code-static-analysis() {
     colorecho "Installing Vulny Code Static Analysis"
-    git -C /opt/tools/ clone --depth=1 https://github.com/swisskyrepo/Vulny-Code-Static-Analysis
+    git -C /opt/tools/ clone --depth 1 https://github.com/swisskyrepo/Vulny-Code-Static-Analysis
+    rm -rf /opt/tools/Vulny-Code-Static-Analysis/.git
     add-aliases vulny-code-static-analysis
     add-test-command "vulny-code-static-analysis --help"
     add-to-list "vulny-code-static-analysis,https://github.com/swisskyrepo/Vulny-Code-Static-Analysis,Static analysis tool for C code"

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -5,10 +5,10 @@ source common.sh
 
 function install_forensic_apt_tools() {
     fapt pst-utils binwalk foremost testdisk fdisk sleuthkit
-    
+
     add-history testdisk
     add-history fdisk
-    
+
     add-test-command "pst2ldif -V"      # Reads a PST and prints the tree structure to the console
     add-test-command "binwalk --help"   # Tool to find embedded files
     add-test-command "foremost -V"      # Alternative to binwalk
@@ -27,7 +27,8 @@ function install_forensic_apt_tools() {
 function install_volatility2() {
     colorecho "Installing volatility"
     fapt pcregrep libpcre++-dev yara libjpeg-dev zlib1g-dev
-    git -C /opt/tools/ clone --depth=1 https://github.com/volatilityfoundation/volatility
+    git -C /opt/tools/ clone --depth 1 https://github.com/volatilityfoundation/volatility
+    rm -rf /opt/tools/volatility/.git
     cd /opt/tools/volatility
     virtualenv -p /usr/bin/python2 ./venv
     ./venv/bin/python2 -m pip install pycrypto distorm3 pillow openpyxl
@@ -71,15 +72,17 @@ function install_trid() {
 
 function install_peepdf() {
     colorecho "Installing peepdf"
-    git -C /opt/tools clone --depth=1 https://github.com/jesparza/peepdf
+    git -C /opt/tools clone --depth 1 https://github.com/jesparza/peepdf
+    rm -rf /opt/tools/peepdf/.git
     add-aliases peepdf
     add-test-command "peepdf --help"
     add-to-list "peepdf,https://github.com/jesparza/peepdf,peepdf is a Python tool to explore PDF files in order to find out if the file can be harmful or not."
-} 
+}
 
 function install_jadx() {
     colorecho "Installing jadx"
-    git -C /opt/tools/ clone --depth=1 https://github.com/skylot/jadx.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/skylot/jadx.git
+    rm -rf /opt/tools/jadx/.git
     cd /opt/tools/jadx
     ./gradlew dist
     ln -v -s /opt/tools/jadx/build/jadx/bin/jadx /opt/tools/bin/jadx

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -49,7 +49,8 @@ function install_network_apt_tools() {
 
 function install_proxychains() {
     colorecho "Installing proxychains"
-    git -C /opt/tools/ clone --depth=1 https://github.com/rofl0r/proxychains-ng
+    git -C /opt/tools/ clone --depth 1 https://github.com/rofl0r/proxychains-ng
+    rm -rf /opt/tools/proxychains-ng/.git
     cd /opt/tools/proxychains-ng
     ./configure --prefix=/usr --sysconfdir=/etc
     make
@@ -77,9 +78,11 @@ function install_nmap() {
 
 function install_autorecon() {
     colorecho "Installing autorecon"
-    git -C /opt/tools/ clone --depth=1 https://gitlab.com/kalilinux/packages/oscanner.git
+    git -C /opt/tools/ clone --depth 1 https://gitlab.com/kalilinux/packages/oscanner.git
+    rm -rf /opt/tools/oscanner/.git
     ln -sv /opt/tools/oscanner/debian/helper-script/oscanner /usr/bin/oscanner
-    git -C /opt/tools clone --depth=1 https://gitlab.com/kalilinux/packages/tnscmd10g.git
+    git -C /opt/tools clone --depth 1 https://gitlab.com/kalilinux/packages/tnscmd10g.git
+    rm -rf /opt/tools/tnscmd10g/.git
     ln -sv /opt/tools/tnscmd10g/tnscmd10g /usr/bin/tnscmd10g
     fapt dnsrecon wkhtmltopdf
     python3 -m pipx install git+https://github.com/Tib3rius/AutoRecon
@@ -92,7 +95,8 @@ function install_autorecon() {
 
 function install_dnschef() {
     colorecho "Installing DNSChef"
-    git -C /opt/tools/ clone --depth=1 https://github.com/iphelix/dnschef
+    git -C /opt/tools/ clone --depth 1 https://github.com/iphelix/dnschef
+    rm -rf /opt/tools/dnschef/.git
     cd /opt/tools/dnschef
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt

--- a/sources/install/package_osint.sh
+++ b/sources/install/package_osint.sh
@@ -9,7 +9,7 @@ function configure_tor() {
 
 function install_osint_apt_tools() {
     fapt exiftool exifprobe dnsenum tor
-    
+
     add-test-command "wget -O /tmp/duck.png https://play-lh.googleusercontent.com/A6y8kFPu6iiFg7RSkGxyNspjOBmeaD3oAOip5dqQvXASnZp-Vg65jigJJLHr5mOEOryx && exiftool /tmp/duck.png && rm /tmp/duck.png" # For read exif information
     add-test-command "exifprobe -V; exifprobe -V |& grep 'Hubert Figuiere'"             # Probe and report structure and metadata content of camera image files
     add-test-command "dnsenum --help; dnsenum --help |& grep 'Print this help message'" # DNSEnum is a command-line tool that automatically identifies basic DNS records
@@ -87,12 +87,13 @@ function install_holehe() {
 
 function install_simplyemail() {
     colorecho "Installing SimplyEmail"
-    git -C /opt/tools/ clone --branch master --depth=1 https://github.com/killswitch-GUI/SimplyEmail.git
+    git -C /opt/tools/ clone --branch master --depth 1 https://github.com/killswitch-GUI/SimplyEmail.git
+    rm -rf /opt/tools/SimplyEmail/.git
     cd /opt/tools/SimplyEmail/
     fapt antiword odt2txt python-dev libxml2-dev libxslt1-dev
     virtualenv -p /usr/bin/python2 ./venv
     ./venv/bin/python2 -m pip install -r ./setup/requirments.txt
-    
+
     add-aliases simplyemail
     add-history simplyemail
     add-test-command "SimplyEmail -l"
@@ -101,7 +102,8 @@ function install_simplyemail() {
 
 function install_theharvester() {
     colorecho "Installing theHarvester"
-    git -C /opt/tools/ clone --depth=1 https://github.com/laramies/theHarvester
+    git -C /opt/tools/ clone --depth 1 https://github.com/laramies/theHarvester
+    rm -rf /opt/tools/theHarvester/.git
     cd /opt/tools/theHarvester
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -123,7 +125,8 @@ function install_h8mail() {
 
 function install_infoga() {
     colorecho "Installing infoga"
-    git -C /opt/tools/ clone --depth=1 https://github.com/m4ll0k/Infoga
+    git -C /opt/tools/ clone --depth 1 https://github.com/m4ll0k/Infoga
+    rm -rf /opt/tools/Infoga/.git
     find /opt/tools/Infoga/ -type f -print0 | xargs -0 dos2unix
     cd /opt/tools/Infoga
     python3 -m venv ./venv
@@ -144,7 +147,8 @@ function install_buster() {
 
 function install_pwnedornot() {
     colorecho "Installing pwnedornot"
-    git -C /opt/tools/ clone --depth=1 https://github.com/thewhiteh4t/pwnedOrNot
+    git -C /opt/tools/ clone --depth 1 https://github.com/thewhiteh4t/pwnedOrNot
+    rm -rf /opt/tools/pwnedOrNot/.git
     cd /opt/tools/pwnedOrNot
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install requests html2text
@@ -183,7 +187,8 @@ function install_maigret() {
 
 function install_linkedin2username() {
     colorecho "Installing linkedin2username"
-    git -C /opt/tools/ clone --depth=1 https://github.com/initstring/linkedin2username
+    git -C /opt/tools/ clone --depth 1 https://github.com/initstring/linkedin2username
+    rm -rf /opt/tools/linkedin2username/.git
     cd /opt/tools/linkedin2username
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -211,7 +216,8 @@ function install_waybackurls() {
 
 function install_carbon14() {
     colorecho "Installing Carbon14"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Lazza/Carbon14
+    git -C /opt/tools/ clone --depth 1 https://github.com/Lazza/Carbon14
+    rm -rf /opt/tools/Carbon14/.git
     cd /opt/tools/Carbon14
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -223,7 +229,8 @@ function install_carbon14() {
 
 function install_photon() {
     colorecho "Installing photon"
-    git -C /opt/tools/ clone --depth=1 https://github.com/s0md3v/photon
+    git -C /opt/tools/ clone --depth 1 https://github.com/s0md3v/photon
+    rm -rf /opt/tools/photon/.git
     cd /opt/tools/photon
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -267,7 +274,8 @@ function install_maltego(){
 
 function install_spiderfoot(){
     colorecho "Installing Spiderfoot"
-    git -C /opt/tools/ clone --depth=1 https://github.com/smicallef/spiderfoot
+    git -C /opt/tools/ clone --depth 1 https://github.com/smicallef/spiderfoot
+    rm -rf /opt/tools/spiderfoot/.git
     cd /opt/tools/spiderfoot
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -280,7 +288,8 @@ function install_spiderfoot(){
 
 function install_finalrecon(){
     colorecho "Installing FinalRecon"
-    git -C /opt/tools/ clone --depth=1 https://github.com/thewhiteh4t/FinalRecon
+    git -C /opt/tools/ clone --depth 1 https://github.com/thewhiteh4t/FinalRecon
+    rm -rf /opt/tools/FinalRecon/.git
     cd /opt/tools/FinalRecon
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -291,7 +300,8 @@ function install_finalrecon(){
 
 function install_pwndb() {
     colorecho "Installing pwndb"
-    git -C /opt/tools/ clone --depth=1 https://github.com/davidtavarez/pwndb.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/davidtavarez/pwndb.git
+    rm -rf /opt/tools/pwndb/.git
     cd /opt/tools/pwndb
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -312,7 +322,8 @@ function install_githubemail() {
 
 function install_recondog() {
     colorecho "Installing ReconDog"
-    git -C /opt/tools/ clone --depth=1 https://github.com/s0md3v/ReconDog
+    git -C /opt/tools/ clone --depth 1 https://github.com/s0md3v/ReconDog
+    rm -rf /opt/tools/ReconDog/.git
     cd /opt/tools/ReconDog/
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -329,7 +340,8 @@ function install_gron() {
 }
 
 function install_trevorspray() {
-    git -C /opt/tools/ clone --depth=1 https://github.com/blacklanternsecurity/TREVORspray
+    git -C /opt/tools/ clone --depth 1 https://github.com/blacklanternsecurity/TREVORspray
+    rm -rf /opt/tools/TREVORspray/.git
     cd /opt/tools/TREVORspray
     # https://github.com/blacklanternsecurity/TREVORspray/pull/27
     sed -i "s/1.0.5/1.0.4/" pyproject.toml

--- a/sources/install/package_reverse.sh
+++ b/sources/install/package_reverse.sh
@@ -5,7 +5,7 @@ source common.sh
 
 function install_reverse_apt_tools() {
     fapt nasm wabt strace
-    
+
     if [[ $(uname -m) = 'x86_64' ]]
     then
         fapt ltrace
@@ -35,7 +35,8 @@ function install_pwntools() {
 
 function install_pwndbg() {
     colorecho "Installing pwndbg"
-    git -C /opt/tools/ clone --depth=1 https://github.com/pwndbg/pwndbg
+    git -C /opt/tools/ clone --depth 1 https://github.com/pwndbg/pwndbg
+    rm -rf /opt/tools/pwndbg/.git
     cd /opt/tools/pwndbg
     ./setup.sh
     echo 'set disassembly-flavor intel' >> ~/.gdbinit
@@ -62,6 +63,7 @@ function install_checksec-py() {
 function install_radare2(){
     colorecho "Installing radare2"
     git -C /opt/tools/ clone https://github.com/radareorg/radare2
+    rm -rf /opt/tools/radare2/.git
     /opt/tools/radare2/sys/install.sh
     add-test-command "radare2 -h"
     add-to-list "radare2,https://github.com/radareorg/radare2,A complete framework for reverse-engineering and analyzing binaries"

--- a/sources/install/package_rfid.sh
+++ b/sources/install/package_rfid.sh
@@ -5,7 +5,7 @@ source common.sh
 
 function install_rfid_apt_tools() {
     fapt libusb-dev autoconf nfct pcsc-tools pcscd libpcsclite-dev libpcsclite1 libnfc-dev libnfc-bin mfcuk
-    
+
     add-history libnfc
 
     add-test-command "dpkg -l libusb-dev | grep 'libusb-dev'"
@@ -25,7 +25,8 @@ function install_rfid_apt_tools() {
 
 function install_mfoc() {
     colorecho "Installing mfoc"
-    git -C /opt/tools/ clone --depth=1 https://github.com/nfc-tools/mfoc
+    git -C /opt/tools/ clone --depth 1 https://github.com/nfc-tools/mfoc
+    rm -rf /opt/tools/mfoc/.git
     cd /opt/tools/mfoc
     autoreconf -vis
     ./configure
@@ -38,7 +39,8 @@ function install_mfoc() {
 
 function install_libnfc-crypto1-crack() {
     colorecho "Installing libnfc-crypto1-crack"
-    git -C /opt/tools/ clone --depth=1 https://github.com/aczid/crypto1_bs
+    git -C /opt/tools/ clone --depth 1 https://github.com/aczid/crypto1_bs
+    rm -rf /opt/tools/crypto1_bs/.git
     cd /opt/tools/crypto1_bs
     wget https://github.com/droidnewbie2/acr122uNFC/raw/master/crapto1-v3.3.tar.xz
     wget https://github.com/droidnewbie2/acr122uNFC/raw/master/craptev1-v1.1.tar.xz
@@ -55,7 +57,8 @@ function install_libnfc-crypto1-crack() {
 
 function install_mfdread() {
     colorecho "Installing mfdread"
-    git -C /opt/tools/ clone --depth=1 https://github.com/zhovner/mfdread
+    git -C /opt/tools/ clone --depth 1 https://github.com/zhovner/mfdread
+    rm -rf /opt/tools/mfdread/.git
     cd /opt/tools/mfdread
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install bitstring
@@ -70,7 +73,8 @@ function install_proxmark3() {
     colorecho "Compiling proxmark client for generic usage with PLATFORM=PM3OTHER (read https://github.com/RfidResearchGroup/proxmark3/blob/master/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md#platform)"
     colorecho "It can be compiled again for RDV4.0 with 'make clean && make all && make install' from /opt/tools/proxmak3/"
     fapt --no-install-recommends git ca-certificates build-essential pkg-config libreadline-dev gcc-arm-none-eabi libnewlib-dev qtbase5-dev libbz2-dev libbluetooth-dev
-    git -C /opt/tools/ clone --depth=1 https://github.com/RfidResearchGroup/proxmark3.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/RfidResearchGroup/proxmark3.git
+    rm -rf /opt/tools/proxmark3/.git
     cd /opt/tools/proxmark3
     make clean
     make all PLATFORM=PM3OTHER

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -5,13 +5,13 @@ source common.sh
 
 function install_web_apt_tools() {
     fapt dirb wfuzz sqlmap sslscan weevely whatweb prips swaks
-  
+
     add-history dirb
     add-history wfuzz
     add-history sqlmap
     add-history prips
     add-history swaks
-  
+
     add-test-command "dirb | grep '<username:password>'" # Web fuzzer
     add-test-command "wfuzz --help"                      # Web fuzzer (second favorites) FIXME Pycurl is not compiled against Openssl
     add-test-command "sqlmap --version"                  # SQL injection scanner
@@ -41,7 +41,8 @@ function install_gobuster() {
 
 function install_kiterunner() {
     colorecho "Installing kiterunner (kr)"
-    git -C /opt/tools/ clone --depth=1 https://github.com/assetnote/kiterunner.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/assetnote/kiterunner.git
+    rm -rf /opt/tools/kiterunner/.git
     cd /opt/tools/kiterunner
     wget https://wordlists-cdn.assetnote.io/data/kiterunner/routes-large.kite.tar.gz
     wget https://wordlists-cdn.assetnote.io/data/kiterunner/routes-small.kite.tar.gz
@@ -77,7 +78,8 @@ function install_dirsearch() {
 
 function install_ssrfmap() {
     colorecho "Installing SSRFmap"
-    git -C /opt/tools/ clone --depth=1 https://github.com/swisskyrepo/SSRFmap
+    git -C /opt/tools/ clone --depth 1 https://github.com/swisskyrepo/SSRFmap
+    rm -rf /opt/tools/SSRFmap/.git
     cd /opt/tools/SSRFmap
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -88,7 +90,8 @@ function install_ssrfmap() {
 
 function install_gopherus() {
     colorecho "Installing gopherus"
-    git -C /opt/tools/ clone --depth=1 https://github.com/tarunkant/Gopherus
+    git -C /opt/tools/ clone --depth 1 https://github.com/tarunkant/Gopherus
+    rm -rf /opt/tools/Gopherus/.git
     cd /opt/tools/Gopherus
     virtualenv -p /usr/bin/python2 ./venv
     ./venv/bin/python2 -m pip install argparse requests
@@ -100,7 +103,8 @@ function install_gopherus() {
 function install_nosqlmap() {
     # TODO : Fix this tool - Python2 or python3 ?
     colorecho "Installing NoSQLMap"
-    git -C /opt/tools clone --depth=1 https://github.com/codingo/NoSQLMap.git
+    git -C /opt/tools clone --depth 1 https://github.com/codingo/NoSQLMap.git
+    rm -rf /opt/tools/NoSQLMap/.git
     cd /opt/tools/NoSQLMap
     virtualenv -p /usr/bin/python2 ./venv
     ./venv/bin/python2 setup.py install
@@ -111,7 +115,8 @@ function install_nosqlmap() {
 
 function install_xsstrike() {
     colorecho "Installing XSStrike"
-    git -C /opt/tools/ clone --depth=1 https://github.com/s0md3v/XSStrike.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/s0md3v/XSStrike.git
+    rm -rf /opt/tools/XSStrike/.git
     cd /opt/tools/XSStrike
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -137,7 +142,8 @@ function install_xsrfprobe() {
 
 function install_bolt() {
     colorecho "Installing Bolt"
-    git -C /opt/tools/ clone --depth=1 https://github.com/s0md3v/Bolt.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/s0md3v/Bolt.git
+    rm -rf /opt/tools/Bolt/.git
     cd /opt/tools/Bolt
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -150,7 +156,8 @@ function install_kadimus() {
     colorecho "Installing kadimus"
     # TODO : Check if deps are already installed
     fapt libcurl4-openssl-dev libpcre3-dev libssh-dev
-    git -C /opt/tools/ clone --depth=1 https://github.com/P0cL4bs/Kadimus
+    git -C /opt/tools/ clone --depth 1 https://github.com/P0cL4bs/Kadimus
+    rm -rf /opt/tools/Kadimus/.git
     cd /opt/tools/Kadimus
     make
     add-aliases kadimus
@@ -161,7 +168,8 @@ function install_kadimus() {
 
 function install_fuxploider() {
     colorecho "Installing fuxploider"
-    git -C /opt/tools/ clone --depth=1 https://github.com/almandin/fuxploider.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/almandin/fuxploider.git
+    rm -rf /opt/tools/fuxploider/.git
     cd /opt/tools/fuxploider
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -172,7 +180,8 @@ function install_fuxploider() {
 
 function install_joomscan(){
     colorecho "Installing joomscan"
-    git -C /opt/tools/ clone --depth=1 https://github.com/rezasp/joomscan
+    git -C /opt/tools/ clone --depth 1 https://github.com/rezasp/joomscan
+    rm -rf /opt/tools/joomscan/.git
     add-aliases joomscan
     add-history joomscan
     add-test-command "joomscan --version"
@@ -203,6 +212,7 @@ function install_droopescan() {
 function install_drupwn() {
     colorecho "Installing drupwn"
     git -C /opt/tools/ clone https://github.com/immunIT/drupwn
+    rm -rf /opt/tools/drupwn/.git
     python3 -m pipx install git+https://github.com/immunIT/drupwn
     add-test-command "drupwn --help"
     add-aliases drupwn
@@ -222,7 +232,8 @@ function install_cmsmap() {
 
 function install_moodlescan() {
     colorecho "Installing moodlescan"
-    git -C /opt/tools/ clone --depth=1 https://github.com/inc0d3/moodlescan.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/inc0d3/moodlescan.git
+    rm -rf /opt/tools/moodlescan/.git
     cd /opt/tools/moodlescan
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -241,7 +252,8 @@ function install_testssl() {
     colorecho "Installing testssl"
     # TODO : Check if deps are already installed
     fapt bsdmainutils
-    git -C /opt/tools/ clone --depth=1 https://github.com/drwetter/testssl.sh.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/drwetter/testssl.sh.git
+    rm -rf /opt/tools/testssl.sh/.git
     add-aliases testssl
     add-test-command "testssl --help"
     add-to-list "testssl,https://github.com/drwetter/testssl.sh,a tool for testing SSL/TLS encryption on servers"
@@ -251,6 +263,7 @@ function install_tls-scanner() {
     colorecho "Installing TLS-Scanner"
     fapt maven
     git -C /opt/tools/ clone https://github.com/tls-attacker/TLS-Scanner
+    rm -rf /opt/tools/TLS-Scanner/.git
     cd /opt/tools/TLS-Scanner
     git submodule update --init --recursive
     mvn clean package -DskipTests=true
@@ -262,7 +275,8 @@ function install_tls-scanner() {
 
 function install_cloudfail() {
     colorecho "Installing CloudFail"
-    git -C /opt/tools/ clone --depth=1 https://github.com/m0rtem/CloudFail
+    git -C /opt/tools/ clone --depth 1 https://github.com/m0rtem/CloudFail
+    rm -rf /opt/tools/CloudFail/.git
     cd /opt/tools/CloudFail
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -274,7 +288,8 @@ function install_cloudfail() {
 
 function install_eyewitness() {
     colorecho "Installing EyeWitness"
-    git -C /opt/tools/ clone --depth=1 https://github.com/FortyNorthSecurity/EyeWitness
+    git -C /opt/tools/ clone --depth 1 https://github.com/FortyNorthSecurity/EyeWitness
+    rm -rf /opt/tools/EyeWitness/.git
     cd /opt/tools/EyeWitness
     python3 -m venv ./venv
     source ./venv/bin/activate
@@ -287,7 +302,8 @@ function install_eyewitness() {
 
 function install_oneforall() {
     colorecho "Installing OneForAll"
-    git -C /opt/tools/ clone --depth=1 https://github.com/shmilylty/OneForAll.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/shmilylty/OneForAll.git
+    rm -rf /opt/tools/OneForAll/.git
     cd /opt/tools/OneForAll
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -305,7 +321,8 @@ function install_wafw00f() {
 
 function install_corscanner() {
     colorecho "Installing CORScanner"
-    git -C /opt/tools/ clone --depth=1 https://github.com/chenjj/CORScanner.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/chenjj/CORScanner.git
+    rm -rf /opt/tools/CORScanner/.git
     cd /opt/tools/CORScanner
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -333,7 +350,8 @@ function install_gowitness() {
 
 function install_linkfinder() {
     colorecho "Installing LinkFinder"
-    git -C /opt/tools/ clone --depth=1 https://github.com/GerbenJavado/LinkFinder.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/GerbenJavado/LinkFinder.git
+    rm -rf /opt/tools/LinkFinder/.git
     cd /opt/tools/LinkFinder
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -360,7 +378,8 @@ function install_updog() {
 
 function install_jwt_tool() {
     colorecho "Installing JWT tool"
-    git -C /opt/tools/ clone --depth=1 https://github.com/ticarpi/jwt_tool
+    git -C /opt/tools/ clone --depth 1 https://github.com/ticarpi/jwt_tool
+    rm -rf /opt/tools/jwt_tool/.git
     cd /opt/tools/jwt_tool
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -385,7 +404,8 @@ function install_git-dumper() {
 
 function install_gittools() {
     colorecho "Installing GitTools"
-    git -C /opt/tools/ clone --depth=1 https://github.com/internetwache/GitTools.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/internetwache/GitTools.git
+    rm -rf /opt/tools/GitTools/.git
     cd /opt/tools/GitTools/Finder
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -407,7 +427,8 @@ function install_ysoserial() {
 
 function install_phpggc() {
     colorecho "Installing phpggc"
-    git -C /opt/tools clone --depth=1 https://github.com/ambionics/phpggc.git
+    git -C /opt/tools clone --depth 1 https://github.com/ambionics/phpggc.git
+    rm -rf /opt/tools/phpggc/.git
     add-aliases phpggc
     add-test-command "phpggc --help"
     add-to-list "phpggc,https://github.com/ambionics/phpggc,Exploit generation tool for the PHP platform."
@@ -415,7 +436,8 @@ function install_phpggc() {
 
 function install_symfony-exploits(){
     colorecho "Installing symfony-exploits"
-    git -C /opt/tools clone --depth=1 https://github.com/ambionics/symfony-exploits
+    git -C /opt/tools clone --depth 1 https://github.com/ambionics/symfony-exploits
+    rm -rf /opt/tools/symfony-exploits/.git
     add-aliases symfony-exploits
     add-test-command "secret_fragment_exploit.py --help"
     add-to-list "symfony-exploits,https://github.com/ambionics/symfony-exploits,Collection of Symfony exploits and PoCs."
@@ -423,7 +445,8 @@ function install_symfony-exploits(){
 
 function install_jdwp_shellifier(){
     colorecho "Installing jdwp_shellifier"
-    git -C /opt/tools/ clone --depth=1 https://github.com/IOActive/jdwp-shellifier
+    git -C /opt/tools/ clone --depth 1 https://github.com/IOActive/jdwp-shellifier
+    rm -rf /opt/tools/jdwp-shellifier/.git
     add-aliases jdwp-shellifier
     add-test-command "jdwp-shellifier.py --help"
     add-to-list "jdwp,https://github.com/IOActive/jdwp-shellifier,This exploitation script is meant to be used by pentesters against active JDWP service, in order to gain Remote Code Execution."
@@ -431,7 +454,8 @@ function install_jdwp_shellifier(){
 
 function install_httpmethods() {
     colorecho "Installing httpmethods"
-    git -C /opt/tools/ clone --depth=1 https://github.com/ShutdownRepo/httpmethods
+    git -C /opt/tools/ clone --depth 1 https://github.com/ShutdownRepo/httpmethods
+    rm -rf /opt/tools/httpmethods/.git
     cd /opt/tools/httpmethods
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -443,7 +467,8 @@ function install_httpmethods() {
 
 function install_h2csmuggler() {
     colorecho "Installing h2csmuggler"
-    git -C /opt/tools/ clone --depth=1 https://github.com/BishopFox/h2csmuggler
+    git -C /opt/tools/ clone --depth 1 https://github.com/BishopFox/h2csmuggler
+    rm -rf /opt/tools/h2csmuggler/.git
     cd /opt/tools/h2csmuggler
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install h2
@@ -474,7 +499,8 @@ function install_feroxbuster() {
 
 function install_tomcatwardeployer() {
     colorecho "Installing tomcatWarDeployer"
-    git -C /opt/tools/ clone --depth=1 https://github.com/mgeeky/tomcatWarDeployer.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/mgeeky/tomcatWarDeployer.git
+    rm -rf /opt/tools/tomcatWarDeployer/.git
     cd /opt/tools/tomcatWarDeployer
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -485,7 +511,8 @@ function install_tomcatwardeployer() {
 
 function install_clusterd() {
     colorecho "Installing clusterd"
-    git -C /opt/tools/ clone --depth=1 https://github.com/hatRiot/clusterd.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/hatRiot/clusterd.git
+    rm -rf /opt/tools/clusterd/.git
     cd /opt/tools/clusterd
     virtualenv -p /usr/bin/python2 ./venv
     ./venv/bin/python2 -m pip install -r requirements.txt
@@ -586,7 +613,8 @@ function install_burpsuite() {
 
 function install_smuggler() {
     colorecho "Installing smuggler.py"
-    git -C /opt/tools/ clone --depth=1 https://github.com/defparam/smuggler.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/defparam/smuggler.git
+    rm -rf /opt/tools/smuggler/.git
     cd /opt/tools/smuggler
     python3 -m venv ./venv
     add-aliases smuggler
@@ -597,7 +625,8 @@ function install_smuggler() {
 
 function install_php_filter_chain_generator() {
     colorecho "Installing PHP_Filter_Chain_Generator"
-    git -C /opt/tools/ clone --depth=1 https://github.com/synacktiv/php_filter_chain_generator.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/synacktiv/php_filter_chain_generator.git
+    rm -rf /opt/tools/php_filter_chain_generator/.git
     add-aliases php_filter_chain_generator
     add-test-command "php_filter_chain_generator --help"
     add-to-list "PHP filter chain generator,https://github.com/synacktiv/php_filter_chain_generator,TODO"
@@ -606,6 +635,7 @@ function install_php_filter_chain_generator() {
 function install_kraken() {
     colorecho "Installing Kraken"
     git -C /opt/tools clone --recurse-submodules https://github.com/kraken-ng/Kraken.git
+    rm -rf /opt/tools/Kraken/.git
     cd /opt/tools/Kraken
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt

--- a/sources/install/package_wifi.sh
+++ b/sources/install/package_wifi.sh
@@ -5,15 +5,15 @@ source common.sh
 
 function install_wifi_apt_tools() {
     fapt aircrack-ng reaver bully cowpatty
-  
+
     add-aliases aircrack-ng
     add-history aircrack-ng
-  
+
     add-test-command "aircrack-ng --help"                                                # WiFi security auditing tools suite
     add-test-command "reaver --help; reaver --help |& grep 'Tactical Network Solutions'" # Brute force attack against Wifi Protected Setup
     add-test-command "bully --version"                                                   # WPS brute force attack
     add-test-command "cowpatty -V"                                                       # WPA2-PSK Cracking
-  
+
     add-to-list "aircrack-ng,https://www.aircrack-ng.org,A suite of tools for wireless penetration testing"
     add-to-list "reaver,https://github.com/t6x/reaver-wps-fork-t6x,reaver is a tool for brute-forcing WPS (Wireless Protected Setup) PINs."
     add-to-list "bully,https://github.com/aanarchyy/bully,bully is a tool for brute-forcing WPS (Wireless Protected Setup) PINs."
@@ -22,7 +22,8 @@ function install_wifi_apt_tools() {
 
 function install_pyrit() {
     colorecho "Installing pyrit"
-    git -C /opt/tools clone --depth=1 https://github.com/JPaulMora/Pyrit
+    git -C /opt/tools clone --depth 1 https://github.com/JPaulMora/Pyrit
+    rm -rf /opt/tools/Pyrit/.git
     cd /opt/tools/Pyrit
     fapt libpq-dev
     virtualenv -p /usr/bin/python2 ./venv
@@ -42,7 +43,8 @@ function install_pyrit() {
 
 function install_wifite2() {
     colorecho "Installing wifite2"
-    git -C /opt/tools/ clone --depth=1 https://github.com/derv82/wifite2.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/derv82/wifite2.git
+    rm -rf /opt/tools/wifite2/.git
     cd /opt/tools/wifite2
     python3 -m venv ./venv
     ./venv/bin/python3 setup.py install
@@ -69,6 +71,7 @@ function install_hcxtools() {
     colorecho "Installing hcxtools"
     fapt libcurl4 libcurl4-openssl-dev libssl-dev openssl pkg-config
     git -C /opt/tools/ clone https://github.com/ZerBea/hcxtools
+    rm -rf /opt/tools/hcxtools/.git
     cd /opt/tools/hcxtools
     # Checking out to specific commit is a temporary fix to the project no compiling anymore.
     # FIXME whenever possible to stay up to date with project (https://github.com/ZerBea/hcxtools/issues/233)
@@ -85,6 +88,7 @@ function install_hcxdumptool() {
     colorecho "Installing hcxdumptool"
     fapt libcurl4-openssl-dev libssl-dev
     git -C /opt/tools/ clone https://github.com/ZerBea/hcxdumptool
+    rm -rf /opt/tools/hcxdumptool/.git
     cd /opt/tools/hcxdumptool
     # Checking out to specific commit is a temporary fix to the project no compiling anymore.
     # FIXME whenever possible to stay up to date with project (https://github.com/ZerBea/hcxdumptool/issues/232)

--- a/sources/install/package_wordlists.sh
+++ b/sources/install/package_wordlists.sh
@@ -20,6 +20,7 @@ function install_wordlists_apt_tools() {
 function install_seclists() {
     colorecho "Installing seclists"
     git -C /opt clone --single-branch --branch master --depth 1 https://github.com/danielmiessler/SecLists.git seclists
+    rm -rf /opt/seclists/.git
     cd /opt/seclists
     rm -r LICENSE .git* CONTRIBUT* .bin
     add-test-command "[ -d '/opt/seclists/Discovery/' ]"
@@ -53,7 +54,8 @@ function install_pass_station() {
 
 function install_username-anarchy() {
     colorecho "Installing Username-Anarchy"
-    git -C /opt/tools/ clone --depth=1 https://github.com/urbanadventurer/username-anarchy
+    git -C /opt/tools/ clone --depth 1 https://github.com/urbanadventurer/username-anarchy
+    rm -rf /opt/tools/username-anarchy/.git
     add-aliases username-anarchy
     add-test-command "username-anarchy --help"
     add-to-list "username-anarchy,https://github.com/urbanadventurer/username-anarchy,TODO"


### PR DESCRIPTION
# Description
The size of Docker images could be reduced by removing the .git folder for all the tools.

The following code executed in a container based on the image Exegol-full-3.0.2, showed that 1.4GB is consumed by these folders.

```
export j=0
for i in $(find /opt/tools -type d -name ".git" -print); do mv ${i} ${j}; j=$((j+1)); done

du -hs .                                           
1.4G
```

Moreover, when cloning Git repositories, the flag --depth 1 is sometimes used as --depth=1. The equal sign is removed as per `man git-clone`

