### PR TITLE
Fix variable in bloodhound custom query

### DIFF
--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -105,7 +105,7 @@
             "category": "They hate cinnamon",
             "queryList": [{
                 "final": true,
-                "query": "OPTIONAL MATCH (u1:User) WHERE u1.hasspn=true OPTIONAL MATCH (u1)-[r:AdminTo]->(c:Computer) RETURN u"
+                "query": "OPTIONAL MATCH (u:User) WHERE u.hasspn=true OPTIONAL MATCH (u)-[r:AdminTo]->(c:Computer) RETURN u"
             }]
         },
         {


### PR DESCRIPTION
# Description

The query **Kerberoastable users and where they are AdminTo** was invalid as it was returning the variable **u** and using the variable **u1**.
The variable was renamed to **u** to keep consistency with other queries
