### PR TITLE
Replace all git clone --depth=1 by --depth 1 for compliance

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -27,7 +27,7 @@ function install_ad_apt_tools() {
 
 function install_responder() {
     colorecho "Installing Responder"
-    git -C /opt/tools/ clone --depth=1 https://github.com/lgandx/Responder
+    git -C /opt/tools/ clone --depth 1 https://github.com/lgandx/Responder
     add-aliases responder
     add-history responder
     add-test-command "responder --version"
@@ -106,7 +106,7 @@ function install_bloodhound-py() {
 
 function install_bloodhound() {
     colorecho "Installing BloodHound from sources"
-    git -C /opt/tools/ clone --depth=1 https://github.com/BloodHoundAD/BloodHound/
+    git -C /opt/tools/ clone --depth 1 https://github.com/BloodHoundAD/BloodHound/
     mv /opt/tools/BloodHound /opt/tools/BloodHound4
     zsh -c "source ~/.zshrc && cd /opt/tools/BloodHound4 && nvm install 16.13.0 && nvm use 16.13.0 && npm install -g electron-packager && npm install && npm run build:linux"
     add-aliases bloodhound
@@ -138,7 +138,7 @@ function configure_bloodhound() {
 
 function install_cypheroth() {
     colorecho "Installing cypheroth"
-    git -C /opt/tools/ clone --depth=1 https://github.com/seajaysec/cypheroth
+    git -C /opt/tools/ clone --depth 1 https://github.com/seajaysec/cypheroth
     add-aliases cypheroth
     add-history cypheroth
     add-test-command "cypheroth --help|& grep 'Example with Defaults:'"
@@ -190,7 +190,7 @@ function configure_impacket() {
 
 function install_pykek() {
     colorecho "Installing Python Kernel Exploit Kit (pykek) for MS14-068"
-    git -C /opt/tools/ clone --depth=1 https://github.com/preempt/pykek
+    git -C /opt/tools/ clone --depth 1 https://github.com/preempt/pykek
     add-aliases pykek
     add-history pykek
     add-test-command "ms14-068.py |& grep '<clearPassword>'"
@@ -207,7 +207,7 @@ function install_lsassy() {
 
 function install_privexchange() {
     colorecho "Installing privexchange"
-    git -C /opt/tools/ clone --depth=1 https://github.com/dirkjanm/PrivExchange
+    git -C /opt/tools/ clone --depth 1 https://github.com/dirkjanm/PrivExchange
     cd /opt/tools/PrivExchange
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
@@ -228,7 +228,7 @@ function install_ruler() {
 function install_darkarmour() {
     colorecho "Installing darkarmour"
     fapt mingw-w64-tools mingw-w64-common g++-mingw-w64 gcc-mingw-w64 upx-ucl osslsigncode
-    git -C /opt/tools/ clone --depth=1 https://github.com/bats3c/darkarmour
+    git -C /opt/tools/ clone --depth 1 https://github.com/bats3c/darkarmour
     add-aliases darkarmour
     add-history darkarmour
     add-test-command "darkarmour --help"
@@ -238,7 +238,7 @@ function install_darkarmour() {
 function install_amber() {
     colorecho "Installing amber"
     # Installing keystone requirement
-    git -C /opt/tools/ clone --depth=1 https://github.com/EgeBalci/keystone
+    git -C /opt/tools/ clone --depth 1 https://github.com/EgeBalci/keystone
     cd /opt/tools/keystone
     mkdir build && cd build
     ../make-lib.sh
@@ -283,7 +283,7 @@ function configure_powershell() {
 
 function install_krbrelayx() {
     colorecho "Installing krbrelayx"
-    git -C /opt/tools/ clone --depth=1 https://github.com/dirkjanm/krbrelayx
+    git -C /opt/tools/ clone --depth 1 https://github.com/dirkjanm/krbrelayx
     cd /opt/tools/krbrelayx
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install dnspython ldap3 impacket dsinternals
@@ -303,7 +303,7 @@ function configure_krbrelayx() {
 
 function install_evilwinrm() {
     colorecho "Installing evil-winrm"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Hackplayers/evil-winrm
+    git -C /opt/tools/ clone --depth 1 https://github.com/Hackplayers/evil-winrm
     cd /opt/tools/evil-winrm
     bundle install
     add-aliases evil-winrm
@@ -322,7 +322,7 @@ function install_pypykatz() {
 
 function install_enyx() {
     colorecho "Installing enyx"
-    git -C /opt/tools/ clone --depth=1 https://github.com/trickster0/Enyx
+    git -C /opt/tools/ clone --depth 1 https://github.com/trickster0/Enyx
     add-aliases enyx
     add-history enyx
     add-test-command "enyx"
@@ -343,8 +343,8 @@ function install_zerologon() {
     cd /opt/tools/zerologon
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
-    git -C /opt/tools/zerologon clone --depth=1 https://github.com/SecuraBV/CVE-2020-1472 zerologon-scan
-    git -C /opt/tools/zerologon clone --depth=1 https://github.com/dirkjanm/CVE-2020-1472 zerologon-exploit
+    git -C /opt/tools/zerologon clone --depth 1 https://github.com/SecuraBV/CVE-2020-1472 zerologon-scan
+    git -C /opt/tools/zerologon clone --depth 1 https://github.com/dirkjanm/CVE-2020-1472 zerologon-exploit
     add-aliases zerologon
     add-history zerologon
     add-test-command "zerologon-scan| grep Usage"
@@ -353,7 +353,7 @@ function install_zerologon() {
 
 function install_libmspack() {
     colorecho "Installing libmspack"
-    git -C /opt/tools/ clone --depth=1 https://github.com/kyz/libmspack.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/kyz/libmspack.git
     cd /opt/tools/libmspack/libmspack
     ./rebuild.sh
     ./configure
@@ -371,7 +371,7 @@ function install_windapsearch-go() {
     cd /opt/tools/mage
     go run bootstrap.go
     # Install windapsearch tool
-    git -C /opt/tools/ clone --depth=1 https://github.com/ropnop/go-windapsearch
+    git -C /opt/tools/ clone --depth 1 https://github.com/ropnop/go-windapsearch
     cd /opt/tools/go-windapsearch
     /root/go/bin/mage build
     add-aliases windapsearch
@@ -395,7 +395,7 @@ function install_oaburl() {
 
 function install_lnkup() {
     colorecho "Installing LNKUp"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Plazmaz/LNKUp
+    git -C /opt/tools/ clone --depth 1 https://github.com/Plazmaz/LNKUp
     cd /opt/tools/LNKUp
     virtualenv --python=/usr/bin/python2 ./venv
     ./venv/bin/python2 -m pip install -r requirements.txt
@@ -407,7 +407,7 @@ function install_lnkup() {
 
 function install_polenum() {
     colorecho "Installing polenum"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Wh1t3Fox/polenum
+    git -C /opt/tools/ clone --depth 1 https://github.com/Wh1t3Fox/polenum
     cd /opt/tools/polenum
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install impacket
@@ -430,7 +430,7 @@ function install_pth-tools() {
     if [[ $(uname -m) = 'x86_64' ]]
     then
         fapt libreadline8 libreadline-dev
-        git -C /opt/tools clone --depth=1 https://github.com/byt3bl33d3r/pth-toolkit
+        git -C /opt/tools clone --depth 1 https://github.com/byt3bl33d3r/pth-toolkit
         ln -s /usr/lib/x86_64-linux-gnu/libreadline.so /opt/tools/pth-toolkit/lib/libreadline.so.6
         add-aliases pth-tools
         add-history pth-tools
@@ -458,7 +458,7 @@ function install_smtp-user-enum() {
 
 function install_gpp-decrypt() {
     colorecho "Installing gpp-decrypt"
-    git -C /opt/tools/ clone --depth=1 https://github.com/t0thkr1s/gpp-decrypt
+    git -C /opt/tools/ clone --depth 1 https://github.com/t0thkr1s/gpp-decrypt
     cd /opt/tools/gpp-decrypt
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install pycrypto colorama
@@ -470,7 +470,7 @@ function install_gpp-decrypt() {
 
 function install_ntlmv1-multi() {
     colorecho "Installing ntlmv1 multi tool"
-    git -C /opt/tools clone --depth=1 https://github.com/evilmog/ntlmv1-multi
+    git -C /opt/tools clone --depth 1 https://github.com/evilmog/ntlmv1-multi
     add-aliases ntlmv1-multi
     add-history ntlmv1-multi
     add-test-command "ntlmv1-multi --ntlmv1 a::a:a:a:a"
@@ -503,7 +503,7 @@ function install_adidnsdump() {
 
 function install_pygpoabuse() {
     colorecho "Installing pyGPOabuse"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Hackndo/pyGPOAbuse
+    git -C /opt/tools/ clone --depth 1 https://github.com/Hackndo/pyGPOAbuse
     cd /opt/tools/pyGPOAbuse
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -523,7 +523,7 @@ function install_bloodhound-import() {
 
 function install_bloodhound-quickwin() {
     colorecho "Installing bloodhound-quickwin"
-    git -C /opt/tools/ clone --depth=1 https://github.com/kaluche/bloodhound-quickwin
+    git -C /opt/tools/ clone --depth 1 https://github.com/kaluche/bloodhound-quickwin
     cd /opt/tools/bloodhound-quickwin
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install py2neo pandas prettytable
@@ -535,7 +535,7 @@ function install_bloodhound-quickwin() {
 
 function install_ldapsearch-ad() {
     colorecho "Installing ldapsearch-ad"
-    git -C /opt/tools/ clone --depth=1 https://github.com/yaap7/ldapsearch-ad
+    git -C /opt/tools/ clone --depth 1 https://github.com/yaap7/ldapsearch-ad
     cd /opt/tools/ldapsearch-ad
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -547,12 +547,12 @@ function install_ldapsearch-ad() {
 
 function install_petitpotam() {
     colorecho "Installing PetitPotam"
-    git -C /opt/tools/ clone --depth=1 https://github.com/ly4k/PetitPotam
+    git -C /opt/tools/ clone --depth 1 https://github.com/ly4k/PetitPotam
     cd /opt/tools/PetitPotam
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
     mv /opt/tools/PetitPotam /opt/tools/PetitPotam_alt
-    git -C /opt/tools/ clone --depth=1 https://github.com/topotam/PetitPotam
+    git -C /opt/tools/ clone --depth 1 https://github.com/topotam/PetitPotam
     cd /opt/tools/PetitPotam
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
@@ -564,7 +564,7 @@ function install_petitpotam() {
 
 function install_dfscoerce() {
     colorecho "Installing DfsCoerce"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Wh04m1001/DFSCoerce
+    git -C /opt/tools/ clone --depth 1 https://github.com/Wh04m1001/DFSCoerce
     cd /opt/tools/DFSCoerce
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
@@ -584,7 +584,7 @@ function install_coercer() {
 
 function install_pkinittools() {
     colorecho "Installing PKINITtools"
-    git -C /opt/tools/ clone --depth=1 https://github.com/dirkjanm/PKINITtools
+    git -C /opt/tools/ clone --depth 1 https://github.com/dirkjanm/PKINITtools
     cd /opt/tools/PKINITtools
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -596,7 +596,7 @@ function install_pkinittools() {
 
 function install_pywhisker() {
     colorecho "Installing pyWhisker"
-    git -C /opt/tools/ clone --depth=1 https://github.com/ShutdownRepo/pywhisker
+    git -C /opt/tools/ clone --depth 1 https://github.com/ShutdownRepo/pywhisker
     cd /opt/tools/pywhisker
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -608,7 +608,7 @@ function install_pywhisker() {
 
 function install_manspider() {
     colorecho "Installing Manspider"
-    git -C /opt/tools clone --depth=1 https://github.com/blacklanternsecurity/MANSPIDER.git
+    git -C /opt/tools clone --depth 1 https://github.com/blacklanternsecurity/MANSPIDER.git
     cd /opt/tools/MANSPIDER
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install .
@@ -635,7 +635,7 @@ function install_targetedKerberoast() {
 function install_pcredz() {
     colorecho "Installing PCredz"
     fapt libpcap-dev
-    git -C /opt/tools/ clone --depth=1 https://github.com/lgandx/PCredz
+    git -C /opt/tools/ clone --depth 1 https://github.com/lgandx/PCredz
     cd /opt/tools/PCredz
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install Cython
@@ -648,7 +648,7 @@ function install_pcredz() {
 
 function install_pywsus() {
     colorecho "Installing pywsus"
-    git -C /opt/tools/ clone --depth=1 https://github.com/GoSecure/pywsus
+    git -C /opt/tools/ clone --depth 1 https://github.com/GoSecure/pywsus
     cd /opt/tools/pywsus
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r ./requirements.txt
@@ -660,7 +660,7 @@ function install_pywsus() {
 
 function install_donpapi() {
     colorecho "Installing DonPAPI"
-    git -C /opt/tools/ clone --depth=1 https://github.com/login-securite/DonPAPI.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/login-securite/DonPAPI.git
     cd /opt/tools/DonPAPI
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r ./requirements.txt
@@ -688,7 +688,7 @@ function install_certipy() {
 
 function install_shadowcoerce() {
     colorecho "Installing ShadowCoerce PoC"
-    git -C /opt/tools/ clone --depth=1 https://github.com/ShutdownRepo/ShadowCoerce
+    git -C /opt/tools/ clone --depth 1 https://github.com/ShutdownRepo/ShadowCoerce
     cd /opt/tools/ShadowCoerce
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
@@ -700,7 +700,7 @@ function install_shadowcoerce() {
 
 function install_gmsadumper() {
     colorecho "Installing gMSADumper"
-    git -C /opt/tools/ clone --depth=1 https://github.com/micahvandeusen/gMSADumper
+    git -C /opt/tools/ clone --depth 1 https://github.com/micahvandeusen/gMSADumper
     cd /opt/tools/gMSADumper
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -712,7 +712,7 @@ function install_gmsadumper() {
 
 function install_pylaps() {
     colorecho "Installing pyLAPS"
-    git -C /opt/tools/ clone --depth=1 https://github.com/p0dalirius/pyLAPS
+    git -C /opt/tools/ clone --depth 1 https://github.com/p0dalirius/pyLAPS
     cd /opt/tools/pyLAPS
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket
@@ -724,7 +724,7 @@ function install_pylaps() {
 
 function install_finduncommonshares() {
     colorecho "Installing FindUncommonShares"
-    git -C /opt/tools/ clone --depth=1 https://github.com/p0dalirius/FindUncommonShares
+    git -C /opt/tools/ clone --depth 1 https://github.com/p0dalirius/FindUncommonShares
     cd /opt/tools/FindUncommonShares/
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -736,7 +736,7 @@ function install_finduncommonshares() {
 
 function install_ldaprelayscan() {
     colorecho "Installing LdapRelayScan"
-    git -C /opt/tools/ clone --depth=1 https://github.com/zyn3rgy/LdapRelayScan
+    git -C /opt/tools/ clone --depth 1 https://github.com/zyn3rgy/LdapRelayScan
     cd /opt/tools/LdapRelayScan
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -756,7 +756,7 @@ function install_goldencopy() {
 
 function install_crackhound() {
     colorecho "Installing CrackHound"
-    git -C /opt/tools/ clone --depth=1 https://github.com/trustedsec/CrackHound
+    git -C /opt/tools/ clone --depth 1 https://github.com/trustedsec/CrackHound
     cd /opt/tools/CrackHound
     prs="6"
     for pr in $prs; do git fetch origin pull/$pr/head:pull/$pr && git merge --strategy-option theirs --no-edit pull/$pr; done
@@ -848,7 +848,7 @@ function install_roastinthemiddle() {
 
 function install_PassTheCert() {
     colorecho "Installing PassTheCert"
-    git -C /opt/tools/ clone --depth=1 https://github.com/AlmondOffSec/PassTheCert
+    git -C /opt/tools/ clone --depth 1 https://github.com/AlmondOffSec/PassTheCert
     cd /opt/tools/PassTheCert/Python/
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install impacket

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -149,7 +149,7 @@ function install_ultimate_vimrc() {
         return
     fi
     colorecho "Installing The Ultimate vimrc"
-    git clone --depth=1 https://github.com/amix/vimrc.git ~/.vim_runtime
+    git clone --depth 1 https://github.com/amix/vimrc.git ~/.vim_runtime
     sh ~/.vim_runtime/install_awesome_vimrc.sh
 }
 
@@ -167,7 +167,7 @@ function install_gf() {
     echo 'source $GOPATH/pkg/mod/github.com/tomnomnom/gf@*/gf-completion.zsh' >> ~/.zshrc
     cp -r /root/go/pkg/mod/github.com/tomnomnom/gf@*/examples ~/.gf
     # Add patterns from 1ndianl33t
-    git -C /opt/tools/ clone --depth=1 https://github.com/1ndianl33t/Gf-Patterns
+    git -C /opt/tools/ clone --depth 1 https://github.com/1ndianl33t/Gf-Patterns
     cp -r /opt/tools/Gf-Patterns/*.json ~/.gf
     # Remove repo to save space
     rm -r /opt/tools/Gf-Patterns

--- a/sources/install/package_code_analysis.sh
+++ b/sources/install/package_code_analysis.sh
@@ -5,7 +5,7 @@ source common.sh
 
 function install_vulny-code-static-analysis() {
     colorecho "Installing Vulny Code Static Analysis"
-    git -C /opt/tools/ clone --depth=1 https://github.com/swisskyrepo/Vulny-Code-Static-Analysis
+    git -C /opt/tools/ clone --depth 1 https://github.com/swisskyrepo/Vulny-Code-Static-Analysis
     add-aliases vulny-code-static-analysis
     add-history vulny-code-static-analysis
     add-test-command "vulny-code-static-analysis --help"

--- a/sources/install/package_crypto.sh
+++ b/sources/install/package_crypto.sh
@@ -16,7 +16,7 @@ function install_rsactftool() {
     colorecho "Installing Rsactftool"
     # This tool uses z3solver, which is very long to build (5 min)
     fapt libmpc-dev
-    git -C /opt/tools clone --depth=1 https://github.com/RsaCtfTool/RsaCtfTool
+    git -C /opt/tools clone --depth 1 https://github.com/RsaCtfTool/RsaCtfTool
     cd /opt/tools/RsaCtfTool
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -29,7 +29,7 @@ function install_forensic_apt_tools() {
 function install_volatility2() {
     colorecho "Installing volatility"
     fapt pcregrep libpcre++-dev yara libjpeg-dev zlib1g-dev
-    git -C /opt/tools/ clone --depth=1 https://github.com/volatilityfoundation/volatility
+    git -C /opt/tools/ clone --depth 1 https://github.com/volatilityfoundation/volatility
     cd /opt/tools/volatility
     virtualenv -p /usr/bin/python2 ./venv
     ./venv/bin/python2 -m pip install pycrypto distorm3 pillow openpyxl
@@ -76,7 +76,7 @@ function install_trid() {
 
 function install_peepdf() {
     colorecho "Installing peepdf"
-    git -C /opt/tools clone --depth=1 https://github.com/jesparza/peepdf
+    git -C /opt/tools clone --depth 1 https://github.com/jesparza/peepdf
     add-aliases peepdf
     add-history peepdf
     add-test-command "peepdf --help"
@@ -85,7 +85,7 @@ function install_peepdf() {
 
 function install_jadx() {
     colorecho "Installing jadx"
-    git -C /opt/tools/ clone --depth=1 https://github.com/skylot/jadx.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/skylot/jadx.git
     cd /opt/tools/jadx
     ./gradlew dist
     ln -v -s /opt/tools/jadx/build/jadx/bin/jadx /opt/tools/bin/jadx

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -57,7 +57,7 @@ function install_network_apt_tools() {
 
 function install_proxychains() {
     colorecho "Installing proxychains"
-    git -C /opt/tools/ clone --depth=1 https://github.com/rofl0r/proxychains-ng
+    git -C /opt/tools/ clone --depth 1 https://github.com/rofl0r/proxychains-ng
     cd /opt/tools/proxychains-ng
     ./configure --prefix=/usr --sysconfdir=/etc
     make
@@ -86,9 +86,9 @@ function install_nmap() {
 
 function install_autorecon() {
     colorecho "Installing autorecon"
-    git -C /opt/tools/ clone --depth=1 https://gitlab.com/kalilinux/packages/oscanner.git
+    git -C /opt/tools/ clone --depth 1 https://gitlab.com/kalilinux/packages/oscanner.git
     ln -sv /opt/tools/oscanner/debian/helper-script/oscanner /usr/bin/oscanner
-    git -C /opt/tools clone --depth=1 https://gitlab.com/kalilinux/packages/tnscmd10g.git
+    git -C /opt/tools clone --depth 1 https://gitlab.com/kalilinux/packages/tnscmd10g.git
     ln -sv /opt/tools/tnscmd10g/tnscmd10g /usr/bin/tnscmd10g
     fapt dnsrecon wkhtmltopdf
     python3 -m pipx install git+https://github.com/Tib3rius/AutoRecon
@@ -101,7 +101,7 @@ function install_autorecon() {
 
 function install_dnschef() {
     colorecho "Installing DNSChef"
-    git -C /opt/tools/ clone --depth=1 https://github.com/iphelix/dnschef
+    git -C /opt/tools/ clone --depth 1 https://github.com/iphelix/dnschef
     cd /opt/tools/dnschef
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt

--- a/sources/install/package_osint.sh
+++ b/sources/install/package_osint.sh
@@ -93,7 +93,7 @@ function install_holehe() {
 
 function install_simplyemail() {
     colorecho "Installing SimplyEmail"
-    git -C /opt/tools/ clone --branch master --depth=1 https://github.com/killswitch-GUI/SimplyEmail.git
+    git -C /opt/tools/ clone --branch master --depth 1 https://github.com/killswitch-GUI/SimplyEmail.git
     cd /opt/tools/SimplyEmail/
     fapt antiword odt2txt python-dev libxml2-dev libxslt1-dev
     virtualenv -p /usr/bin/python2 ./venv
@@ -106,7 +106,7 @@ function install_simplyemail() {
 
 function install_theharvester() {
     colorecho "Installing theHarvester"
-    git -C /opt/tools/ clone --depth=1 https://github.com/laramies/theHarvester
+    git -C /opt/tools/ clone --depth 1 https://github.com/laramies/theHarvester
     cd /opt/tools/theHarvester
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -128,7 +128,7 @@ function install_h8mail() {
 
 function install_infoga() {
     colorecho "Installing infoga"
-    git -C /opt/tools/ clone --depth=1 https://github.com/m4ll0k/Infoga
+    git -C /opt/tools/ clone --depth 1 https://github.com/m4ll0k/Infoga
     find /opt/tools/Infoga/ -type f -print0 | xargs -0 dos2unix
     cd /opt/tools/Infoga
     python3 -m venv ./venv
@@ -156,7 +156,7 @@ function install_buster() {
 
 function install_pwnedornot() {
     colorecho "Installing pwnedornot"
-    git -C /opt/tools/ clone --depth=1 https://github.com/thewhiteh4t/pwnedOrNot
+    git -C /opt/tools/ clone --depth 1 https://github.com/thewhiteh4t/pwnedOrNot
     cd /opt/tools/pwnedOrNot
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install requests html2text
@@ -196,7 +196,7 @@ function install_maigret() {
 
 function install_linkedin2username() {
     colorecho "Installing linkedin2username"
-    git -C /opt/tools/ clone --depth=1 https://github.com/initstring/linkedin2username
+    git -C /opt/tools/ clone --depth 1 https://github.com/initstring/linkedin2username
     cd /opt/tools/linkedin2username
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -224,7 +224,7 @@ function install_waybackurls() {
 
 function install_carbon14() {
     colorecho "Installing Carbon14"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Lazza/Carbon14
+    git -C /opt/tools/ clone --depth 1 https://github.com/Lazza/Carbon14
     cd /opt/tools/Carbon14
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -236,7 +236,7 @@ function install_carbon14() {
 
 function install_photon() {
     colorecho "Installing photon"
-    git -C /opt/tools/ clone --depth=1 https://github.com/s0md3v/photon
+    git -C /opt/tools/ clone --depth 1 https://github.com/s0md3v/photon
     cd /opt/tools/photon
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -283,7 +283,7 @@ function install_maltego() {
 
 function install_spiderfoot() {
     colorecho "Installing Spiderfoot"
-    git -C /opt/tools/ clone --depth=1 https://github.com/smicallef/spiderfoot
+    git -C /opt/tools/ clone --depth 1 https://github.com/smicallef/spiderfoot
     cd /opt/tools/spiderfoot
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -296,7 +296,7 @@ function install_spiderfoot() {
 
 function install_finalrecon() {
     colorecho "Installing FinalRecon"
-    git -C /opt/tools/ clone --depth=1 https://github.com/thewhiteh4t/FinalRecon
+    git -C /opt/tools/ clone --depth 1 https://github.com/thewhiteh4t/FinalRecon
     cd /opt/tools/FinalRecon
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -318,7 +318,7 @@ function install_osrframework() {
 
 function install_pwndb() {
     colorecho "Installing pwndb"
-    git -C /opt/tools/ clone --depth=1 https://github.com/davidtavarez/pwndb.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/davidtavarez/pwndb.git
     cd /opt/tools/pwndb
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -339,7 +339,7 @@ function install_githubemail() {
 
 function install_recondog() {
     colorecho "Installing ReconDog"
-    git -C /opt/tools/ clone --depth=1 https://github.com/s0md3v/ReconDog
+    git -C /opt/tools/ clone --depth 1 https://github.com/s0md3v/ReconDog
     cd /opt/tools/ReconDog/
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -366,7 +366,7 @@ function install_ignorant() {
 }
 
 function install_trevorspray() {
-    git -C /opt/tools/ clone --depth=1 https://github.com/blacklanternsecurity/TREVORspray
+    git -C /opt/tools/ clone --depth 1 https://github.com/blacklanternsecurity/TREVORspray
     cd /opt/tools/TREVORspray
     # https://github.com/blacklanternsecurity/TREVORspray/pull/27
     sed -i "s/1.0.5/1.0.4/" pyproject.toml

--- a/sources/install/package_reverse.sh
+++ b/sources/install/package_reverse.sh
@@ -38,7 +38,7 @@ function install_pwntools() {
 
 function install_pwndbg() {
     colorecho "Installing pwndbg"
-    git -C /opt/tools/ clone --depth=1 https://github.com/pwndbg/pwndbg
+    git -C /opt/tools/ clone --depth 1 https://github.com/pwndbg/pwndbg
     cd /opt/tools/pwndbg
     ./setup.sh
     echo 'set disassembly-flavor intel' >> ~/.gdbinit
@@ -58,7 +58,7 @@ function install_angr() {
 
 function install_checksec-py() {
     colorecho "Installing checksec.py"
-    git -C /opt/tools/ clone --depth=1 https://github.com/Wenzel/checksec.py.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/Wenzel/checksec.py.git
     cd /opt/tools/checksec.py
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install .

--- a/sources/install/package_rfid.sh
+++ b/sources/install/package_rfid.sh
@@ -26,7 +26,7 @@ function install_rfid_apt_tools() {
 
 function install_mfoc() {
     colorecho "Installing mfoc"
-    git -C /opt/tools/ clone --depth=1 https://github.com/nfc-tools/mfoc
+    git -C /opt/tools/ clone --depth 1 https://github.com/nfc-tools/mfoc
     cd /opt/tools/mfoc
     autoreconf -vis
     ./configure
@@ -39,7 +39,7 @@ function install_mfoc() {
 
 function install_libnfc-crypto1-crack() {
     colorecho "Installing libnfc-crypto1-crack"
-    git -C /opt/tools/ clone --depth=1 https://github.com/aczid/crypto1_bs
+    git -C /opt/tools/ clone --depth 1 https://github.com/aczid/crypto1_bs
     cd /opt/tools/crypto1_bs
     wget https://github.com/droidnewbie2/acr122uNFC/raw/master/crapto1-v3.3.tar.xz
     wget https://github.com/droidnewbie2/acr122uNFC/raw/master/craptev1-v1.1.tar.xz
@@ -56,7 +56,7 @@ function install_libnfc-crypto1-crack() {
 
 function install_mfdread() {
     colorecho "Installing mfdread"
-    git -C /opt/tools/ clone --depth=1 https://github.com/zhovner/mfdread
+    git -C /opt/tools/ clone --depth 1 https://github.com/zhovner/mfdread
     cd /opt/tools/mfdread
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install bitstring
@@ -71,7 +71,7 @@ function install_proxmark3() {
     colorecho "Compiling proxmark client for generic usage with PLATFORM=PM3OTHER (read https://github.com/RfidResearchGroup/proxmark3/blob/master/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md#platform)"
     colorecho "It can be compiled again for RDV4.0 with 'make clean && make all && make install' from /opt/tools/proxmak3/"
     fapt --no-install-recommends git ca-certificates build-essential pkg-config libreadline-dev gcc-arm-none-eabi libnewlib-dev qtbase5-dev libbz2-dev libbluetooth-dev
-    git -C /opt/tools/ clone --depth=1 https://github.com/RfidResearchGroup/proxmark3.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/RfidResearchGroup/proxmark3.git
     cd /opt/tools/proxmark3
     make clean
     make all PLATFORM=PM3OTHER

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -51,7 +51,7 @@ function install_gobuster() {
 
 function install_kiterunner() {
     colorecho "Installing kiterunner (kr)"
-    git -C /opt/tools/ clone --depth=1 https://github.com/assetnote/kiterunner.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/assetnote/kiterunner.git
     cd /opt/tools/kiterunner
     wget https://wordlists-cdn.assetnote.io/data/kiterunner/routes-large.kite.tar.gz
     wget https://wordlists-cdn.assetnote.io/data/kiterunner/routes-small.kite.tar.gz
@@ -88,7 +88,7 @@ function install_dirsearch() {
 
 function install_ssrfmap() {
     colorecho "Installing SSRFmap"
-    git -C /opt/tools/ clone --depth=1 https://github.com/swisskyrepo/SSRFmap
+    git -C /opt/tools/ clone --depth 1 https://github.com/swisskyrepo/SSRFmap
     cd /opt/tools/SSRFmap
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -100,7 +100,7 @@ function install_ssrfmap() {
 
 function install_gopherus() {
     colorecho "Installing gopherus"
-    git -C /opt/tools/ clone --depth=1 https://github.com/tarunkant/Gopherus
+    git -C /opt/tools/ clone --depth 1 https://github.com/tarunkant/Gopherus
     cd /opt/tools/Gopherus
     virtualenv -p /usr/bin/python2 ./venv
     ./venv/bin/python2 -m pip install argparse requests
@@ -127,7 +127,7 @@ function install_nosqlmap() {
 
 function install_xsstrike() {
     colorecho "Installing XSStrike"
-    git -C /opt/tools/ clone --depth=1 https://github.com/s0md3v/XSStrike.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/s0md3v/XSStrike.git
     cd /opt/tools/XSStrike
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -168,7 +168,7 @@ function install_xsrfprobe() {
 
 function install_bolt() {
     colorecho "Installing Bolt"
-    git -C /opt/tools/ clone --depth=1 https://github.com/s0md3v/Bolt.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/s0md3v/Bolt.git
     cd /opt/tools/Bolt
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -182,7 +182,7 @@ function install_kadimus() {
     colorecho "Installing kadimus"
     # TODO : Check if deps are already installed
     fapt libcurl4-openssl-dev libpcre3-dev libssh-dev
-    git -C /opt/tools/ clone --depth=1 https://github.com/P0cL4bs/Kadimus
+    git -C /opt/tools/ clone --depth 1 https://github.com/P0cL4bs/Kadimus
     cd /opt/tools/Kadimus
     make
     add-aliases kadimus
@@ -193,7 +193,7 @@ function install_kadimus() {
 
 function install_fuxploider() {
     colorecho "Installing fuxploider"
-    git -C /opt/tools/ clone --depth=1 https://github.com/almandin/fuxploider.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/almandin/fuxploider.git
     cd /opt/tools/fuxploider
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -218,7 +218,7 @@ function install_patator() {
 
 function install_joomscan() {
     colorecho "Installing joomscan"
-    git -C /opt/tools/ clone --depth=1 https://github.com/rezasp/joomscan
+    git -C /opt/tools/ clone --depth 1 https://github.com/rezasp/joomscan
     add-aliases joomscan
     add-history joomscan
     add-test-command "joomscan --version"
@@ -266,7 +266,7 @@ function install_cmsmap() {
 
 function install_moodlescan() {
     colorecho "Installing moodlescan"
-    git -C /opt/tools/ clone --depth=1 https://github.com/inc0d3/moodlescan.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/inc0d3/moodlescan.git
     cd /opt/tools/moodlescan
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -285,7 +285,7 @@ function install_testssl() {
     colorecho "Installing testssl"
     # TODO : Check if deps are already installed
     fapt bsdmainutils
-    git -C /opt/tools/ clone --depth=1 https://github.com/drwetter/testssl.sh.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/drwetter/testssl.sh.git
     add-aliases testssl
     add-history testssl
     add-test-command "testssl --help"
@@ -307,7 +307,7 @@ function install_tls-scanner() {
 
 function install_cloudfail() {
     colorecho "Installing CloudFail"
-    git -C /opt/tools/ clone --depth=1 https://github.com/m0rtem/CloudFail
+    git -C /opt/tools/ clone --depth 1 https://github.com/m0rtem/CloudFail
     cd /opt/tools/CloudFail
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -319,7 +319,7 @@ function install_cloudfail() {
 
 function install_eyewitness() {
     colorecho "Installing EyeWitness"
-    git -C /opt/tools/ clone --depth=1 https://github.com/FortyNorthSecurity/EyeWitness
+    git -C /opt/tools/ clone --depth 1 https://github.com/FortyNorthSecurity/EyeWitness
     cd /opt/tools/EyeWitness
     python3 -m venv ./venv
     source ./venv/bin/activate
@@ -333,7 +333,7 @@ function install_eyewitness() {
 
 function install_oneforall() {
     colorecho "Installing OneForAll"
-    git -C /opt/tools/ clone --depth=1 https://github.com/shmilylty/OneForAll.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/shmilylty/OneForAll.git
     cd /opt/tools/OneForAll
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -353,7 +353,7 @@ function install_wafw00f() {
 
 function install_corscanner() {
     colorecho "Installing CORScanner"
-    git -C /opt/tools/ clone --depth=1 https://github.com/chenjj/CORScanner.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/chenjj/CORScanner.git
     cd /opt/tools/CORScanner
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -382,7 +382,7 @@ function install_gowitness() {
 
 function install_linkfinder() {
     colorecho "Installing LinkFinder"
-    git -C /opt/tools/ clone --depth=1 https://github.com/GerbenJavado/LinkFinder.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/GerbenJavado/LinkFinder.git
     cd /opt/tools/LinkFinder
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -411,7 +411,7 @@ function install_updog() {
 
 function install_jwt_tool() {
     colorecho "Installing JWT tool"
-    git -C /opt/tools/ clone --depth=1 https://github.com/ticarpi/jwt_tool
+    git -C /opt/tools/ clone --depth 1 https://github.com/ticarpi/jwt_tool
     cd /opt/tools/jwt_tool
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -439,7 +439,7 @@ function install_git-dumper() {
 
 function install_gittools() {
     colorecho "Installing GitTools"
-    git -C /opt/tools/ clone --depth=1 https://github.com/internetwache/GitTools.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/internetwache/GitTools.git
     cd /opt/tools/GitTools/Finder
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -463,7 +463,7 @@ function install_ysoserial() {
 
 function install_phpggc() {
     colorecho "Installing phpggc"
-    git -C /opt/tools clone --depth=1 https://github.com/ambionics/phpggc.git
+    git -C /opt/tools clone --depth 1 https://github.com/ambionics/phpggc.git
     add-aliases phpggc
     add-history phpggc
     add-test-command "phpggc --help"
@@ -472,7 +472,7 @@ function install_phpggc() {
 
 function install_symfony-exploits(){
     colorecho "Installing symfony-exploits"
-    git -C /opt/tools clone --depth=1 https://github.com/ambionics/symfony-exploits
+    git -C /opt/tools clone --depth 1 https://github.com/ambionics/symfony-exploits
     add-aliases symfony-exploits
     add-history symfony-exploits
     add-test-command "secret_fragment_exploit.py --help"
@@ -481,7 +481,7 @@ function install_symfony-exploits(){
 
 function install_jdwp_shellifier(){
     colorecho "Installing jdwp_shellifier"
-    git -C /opt/tools/ clone --depth=1 https://github.com/IOActive/jdwp-shellifier
+    git -C /opt/tools/ clone --depth 1 https://github.com/IOActive/jdwp-shellifier
     add-aliases jdwp-shellifier
     add-history jdwp-shellifier
     add-test-command "jdwp-shellifier.py --help"
@@ -490,7 +490,7 @@ function install_jdwp_shellifier(){
 
 function install_httpmethods() {
     colorecho "Installing httpmethods"
-    git -C /opt/tools/ clone --depth=1 https://github.com/ShutdownRepo/httpmethods
+    git -C /opt/tools/ clone --depth 1 https://github.com/ShutdownRepo/httpmethods
     cd /opt/tools/httpmethods
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -502,7 +502,7 @@ function install_httpmethods() {
 
 function install_h2csmuggler() {
     colorecho "Installing h2csmuggler"
-    git -C /opt/tools/ clone --depth=1 https://github.com/BishopFox/h2csmuggler
+    git -C /opt/tools/ clone --depth 1 https://github.com/BishopFox/h2csmuggler
     cd /opt/tools/h2csmuggler
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install h2
@@ -535,7 +535,7 @@ function install_feroxbuster() {
 
 function install_tomcatwardeployer() {
     colorecho "Installing tomcatWarDeployer"
-    git -C /opt/tools/ clone --depth=1 https://github.com/mgeeky/tomcatWarDeployer.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/mgeeky/tomcatWarDeployer.git
     cd /opt/tools/tomcatWarDeployer
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -547,7 +547,7 @@ function install_tomcatwardeployer() {
 
 function install_clusterd() {
     colorecho "Installing clusterd"
-    git -C /opt/tools/ clone --depth=1 https://github.com/hatRiot/clusterd.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/hatRiot/clusterd.git
     cd /opt/tools/clusterd
     virtualenv -p /usr/bin/python2 ./venv
     ./venv/bin/python2 -m pip install -r requirements.txt
@@ -655,7 +655,7 @@ function install_burpsuite() {
 
 function install_smuggler() {
     colorecho "Installing smuggler.py"
-    git -C /opt/tools/ clone --depth=1 https://github.com/defparam/smuggler.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/defparam/smuggler.git
     cd /opt/tools/smuggler
     python3 -m venv ./venv
     add-aliases smuggler
@@ -666,7 +666,7 @@ function install_smuggler() {
 
 function install_php_filter_chain_generator() {
     colorecho "Installing PHP_Filter_Chain_Generator"
-    git -C /opt/tools/ clone --depth=1 https://github.com/synacktiv/php_filter_chain_generator.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/synacktiv/php_filter_chain_generator.git
     add-aliases php_filter_chain_generator
     add-history php_filter_chain_generator
     add-test-command "php_filter_chain_generator --help"

--- a/sources/install/package_wifi.sh
+++ b/sources/install/package_wifi.sh
@@ -26,7 +26,7 @@ function install_wifi_apt_tools() {
 
 function install_pyrit() {
     colorecho "Installing pyrit"
-    git -C /opt/tools clone --depth=1 https://github.com/JPaulMora/Pyrit
+    git -C /opt/tools clone --depth 1 https://github.com/JPaulMora/Pyrit
     cd /opt/tools/Pyrit
     fapt libpq-dev
     virtualenv -p /usr/bin/python2 ./venv
@@ -47,7 +47,7 @@ function install_pyrit() {
 
 function install_wifite2() {
     colorecho "Installing wifite2"
-    git -C /opt/tools/ clone --depth=1 https://github.com/derv82/wifite2.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/derv82/wifite2.git
     cd /opt/tools/wifite2
     python3 -m venv ./venv
     ./venv/bin/python3 setup.py install

--- a/sources/install/package_wordlists.sh
+++ b/sources/install/package_wordlists.sh
@@ -55,7 +55,7 @@ function install_pass_station() {
 
 function install_username-anarchy() {
     colorecho "Installing Username-Anarchy"
-    git -C /opt/tools/ clone --depth=1 https://github.com/urbanadventurer/username-anarchy
+    git -C /opt/tools/ clone --depth 1 https://github.com/urbanadventurer/username-anarchy
     add-aliases username-anarchy
     add-history username-anarchy
     add-test-command "username-anarchy --help"


### PR DESCRIPTION
Hello,

as discussed in https://github.com/ThePorgs/Exegol-images/pull/159, this PR is to remove all --depth=1, as the manual states a whitespace between the word depth and the digit.

```
man git-clone

--depth <depth>
           Create a shallow clone with a history truncated to the specified number of commits. Implies --single-branch unless --no-single-branch is given to fetch the histories near the tips of all branches. If you want to clone
           submodules shallowly, also pass --shallow-submodules.
```

CC @QU35T-code for review