### PR TITLE
Rusthound: remove the duplicated dependency libclang-dev

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -786,7 +786,7 @@ function install_ldeep() {
 
 function install_rusthound() {
     colorecho "Installing RustHound"
-    fapt gcc libclang-dev clang libclang-dev libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit musl-tools gcc-mingw-w64-x86-64
+    fapt gcc clang libclang-dev libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit musl-tools gcc-mingw-w64-x86-64
     git -C /opt/tools/ clone https://github.com/OPENCYBER-FR/RustHound
     cd /opt/tools/RustHound
     # Sourcing rustup shell setup, so that rust binaries are found when installing cme


### PR DESCRIPTION
Hello,

as already reported to [upstream](https://github.com/OPENCYBER-FR/RustHound/pull/17/commits/110a6c1aaf51336c6b4b04d1e898f41e42c7772b), the dependency `libclang-dev` is pulled twice for `Rusthound`.

Removing one for cleaning up.