### PR TITLE
Add the argument --depth 1 to git clone for some tools missing it

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -77,12 +77,12 @@ function install_crackmapexec() {
     # Source bc cme needs cargo PATH (rustc) -> aardwolf dep
     # TODO: Optimize so that the PATH is always up to date
     source /root/.zshrc || true
-    git -C /opt/tools/ clone https://github.com/Porchetta-Industries/CrackMapExec.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/mpgn/CrackMapExec.git
     python3 -m pipx install /opt/tools/CrackMapExec/
     add-aliases crackmapexec
     add-history crackmapexec
     add-test-command "crackmapexec --help"
-    add-to-list "crackmapexec,https://github.com/byt3bl33d3r/CrackMapExec,Network scanner."
+    add-to-list "crackmapexec,https://github.com/mpgn/CrackMapExec,Network scanner."
 }
 
 function configure_crackmapexec() {
@@ -91,7 +91,7 @@ function configure_crackmapexec() {
     [ -f ~/.cme/cme.conf ] && mv ~/.cme/cme.conf ~/.cme/cme.conf.bak
     cp -v /root/sources/assets/crackmapexec/cme.conf ~/.cme/cme.conf
     # below is for having the ability to check the source code when working with modules and so on
-    # git -C /opt/tools/ clone https://github.com/byt3bl33d3r/CrackMapExec
+    # git -C /opt/tools/ clone --depth 1 https://github.com/mpgn/CrackMapExec
     cp -v /root/sources/assets/grc/conf.cme /usr/share/grc/conf.cme
 }
 
@@ -367,7 +367,7 @@ function install_libmspack() {
 function install_windapsearch-go() {
     colorecho "Installing Go windapsearch"
     # Install mage dependency
-    git -C /opt/tools/ clone https://github.com/magefile/mage
+    git -C /opt/tools/ clone --depth 1 https://github.com/magefile/mage
     cd /opt/tools/mage
     go run bootstrap.go
     # Install windapsearch tool
@@ -622,7 +622,7 @@ function install_manspider() {
 
 function install_targetedKerberoast() {
     colorecho "Installing targetedKerberoast"
-    git -C /opt/tools/ clone https://github.com/ShutdownRepo/targetedKerberoast
+    git -C /opt/tools/ clone --depth 1 https://github.com/ShutdownRepo/targetedKerberoast
     cd /opt/tools/targetedKerberoast
     python3 -m venv ./venv/
     ./venv/bin/python3 -m pip install -r requirements.txt
@@ -787,7 +787,7 @@ function install_ldeep() {
 function install_rusthound() {
     colorecho "Installing RustHound"
     fapt gcc clang libclang-dev libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit musl-tools gcc-mingw-w64-x86-64
-    git -C /opt/tools/ clone https://github.com/OPENCYBER-FR/RustHound
+    git -C /opt/tools/ clone --depth 1 https://github.com/OPENCYBER-FR/RustHound
     cd /opt/tools/RustHound
     # Sourcing rustup shell setup, so that rust binaries are found when installing cme
     source "$HOME/.cargo/env"

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -11,8 +11,8 @@ function update() {
 
 function install_exegol-history() {
     colorecho "Installing Exegol-history"
-    #  git -C /opt/tools/ clone https://github.com/ThePorgs/Exegol-history
-    # todo : below is something basic. A nice tool being created for faster and smoother worflow
+    #  git -C /opt/tools/ clone --depth 1 https://github.com/ThePorgs/Exegol-history
+    # todo : below is something basic. A nice tool being created for faster and smoother workflow
     mkdir -p /opt/tools/Exegol-history
     rm -rf /opt/tools/Exegol-history/profile.sh
     echo "#export INTERFACE='eth0'" >> /opt/tools/Exegol-history/profile.sh
@@ -118,11 +118,11 @@ function install_ohmyzsh() {
     colorecho "Installing oh-my-zsh, config, history, aliases"
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
     cp -v /root/sources/assets/zsh/zshrc ~/.zshrc
-    git -C ~/.oh-my-zsh/custom/plugins/ clone https://github.com/zsh-users/zsh-autosuggestions
-    git -C ~/.oh-my-zsh/custom/plugins/ clone https://github.com/zsh-users/zsh-syntax-highlighting
-    git -C ~/.oh-my-zsh/custom/plugins/ clone https://github.com/zsh-users/zsh-completions
-    git -C ~/.oh-my-zsh/custom/plugins/ clone https://github.com/agkozak/zsh-z
-    git -C ~/.oh-my-zsh/custom/plugins/ clone https://github.com/lukechilds/zsh-nvm
+    git -C ~/.oh-my-zsh/custom/plugins/ clone --depth 1 https://github.com/zsh-users/zsh-autosuggestions
+    git -C ~/.oh-my-zsh/custom/plugins/ clone --depth 1 https://github.com/zsh-users/zsh-syntax-highlighting
+    git -C ~/.oh-my-zsh/custom/plugins/ clone --depth 1 https://github.com/zsh-users/zsh-completions
+    git -C ~/.oh-my-zsh/custom/plugins/ clone --depth 1 https://github.com/agkozak/zsh-z
+    git -C ~/.oh-my-zsh/custom/plugins/ clone --depth 1 https://github.com/lukechilds/zsh-nvm
     zsh -c "source ~/.oh-my-zsh/custom/plugins/zsh-nvm/zsh-nvm.plugin.zsh" # this is needed to start an instance of zsh to have the plugin set up
     add-aliases fzf
     add-test-command "fzf-wordlists --help"

--- a/sources/install/package_c2.sh
+++ b/sources/install/package_c2.sh
@@ -45,7 +45,7 @@ function install_routersploit() {
 
 function install_sliver() {
     colorecho "Installing Sliver"
-    git -C /opt/tools/ clone https://github.com/BishopFox/sliver.git
+    git -C /opt/tools/ clone --depth 1 https://github.com/BishopFox/sliver.git
     cd /opt/tools/sliver
     make
     cp sliver-* /opt/tools/bin

--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -85,7 +85,7 @@ function install_trilium() {
     colorecho "Installing Trilium (building from sources)"
     # TODO : apt install in a second step
     fapt libpng16-16 libpng-dev pkg-config autoconf libtool build-essential nasm libx11-dev libxkbfile-dev
-    git -C /opt/tools/ clone -b stable https://github.com/zadam/trilium.git
+    git -C /opt/tools/ clone -b stable --depth 1 https://github.com/zadam/trilium.git
     cd /opt/tools/trilium
     add-aliases trilium
     add-history trilium

--- a/sources/install/package_reverse.sh
+++ b/sources/install/package_reverse.sh
@@ -71,7 +71,7 @@ function install_checksec-py() {
 
 function install_radare2(){
     colorecho "Installing radare2"
-    git -C /opt/tools/ clone https://github.com/radareorg/radare2
+    git -C /opt/tools/ clone --depth 1 https://github.com/radareorg/radare2
     /opt/tools/radare2/sys/install.sh
     add-history radare2
     add-test-command "radare2 -h"

--- a/sources/install/package_sdr.sh
+++ b/sources/install/package_sdr.sh
@@ -22,7 +22,7 @@ function install_sdr_apt_tools() {
 function install_mousejack() {
     colorecho "Installing mousejack"
     fapt sdcc binutils
-    git -C /opt/tools/ clone https://github.com/BastilleResearch/mousejack
+    git -C /opt/tools/ clone --depth 1 https://github.com/BastilleResearch/mousejack
     cd /opt/tools/mousejack
     git submodule init
     git submodule update

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -245,7 +245,7 @@ function install_droopescan() {
 
 function install_drupwn() {
     colorecho "Installing drupwn"
-    git -C /opt/tools/ clone https://github.com/immunIT/drupwn
+    git -C /opt/tools/ clone --depth 1 https://github.com/immunIT/drupwn
     python3 -m pipx install git+https://github.com/immunIT/drupwn
     add-aliases drupwn
     add-history drupwn
@@ -295,7 +295,7 @@ function install_testssl() {
 function install_tls-scanner() {
     colorecho "Installing TLS-Scanner"
     fapt maven
-    git -C /opt/tools/ clone https://github.com/tls-attacker/TLS-Scanner
+    git -C /opt/tools/ clone --depth 1 https://github.com/tls-attacker/TLS-Scanner
     cd /opt/tools/TLS-Scanner
     git submodule update --init --recursive
     mvn clean package -DskipTests=true
@@ -675,7 +675,7 @@ function install_php_filter_chain_generator() {
 
 function install_kraken() {
     colorecho "Installing Kraken"
-    git -C /opt/tools clone --recurse-submodules https://github.com/kraken-ng/Kraken.git
+    git -C /opt/tools clone --depth 1 --recurse-submodules https://github.com/kraken-ng/Kraken.git
     cd /opt/tools/Kraken
     python3 -m venv ./venv
     ./venv/bin/python3 -m pip install -r requirements.txt

--- a/sources/install/package_wifi.sh
+++ b/sources/install/package_wifi.sh
@@ -75,7 +75,7 @@ function install_bettercap() {
 function install_hcxtools() {
     colorecho "Installing hcxtools"
     fapt libcurl4 libcurl4-openssl-dev libssl-dev openssl pkg-config
-    git -C /opt/tools/ clone https://github.com/ZerBea/hcxtools
+    git -C /opt/tools/ clone --depth 1 https://github.com/ZerBea/hcxtools
     cd /opt/tools/hcxtools
     # Checking out to specific commit is a temporary fix to the project no compiling anymore.
     # FIXME whenever possible to stay up to date with project (https://github.com/ZerBea/hcxtools/issues/233)
@@ -91,7 +91,7 @@ function install_hcxtools() {
 function install_hcxdumptool() {
     colorecho "Installing hcxdumptool"
     fapt libcurl4-openssl-dev libssl-dev
-    git -C /opt/tools/ clone https://github.com/ZerBea/hcxdumptool
+    git -C /opt/tools/ clone --depth 1 https://github.com/ZerBea/hcxdumptool
     cd /opt/tools/hcxdumptool
     # Checking out to specific commit is a temporary fix to the project no compiling anymore.
     # FIXME whenever possible to stay up to date with project (https://github.com/ZerBea/hcxdumptool/issues/232)


### PR DESCRIPTION
After reviewing the PR https://github.com/ThePorgs/Exegol-images/pull/177, I noticed that the argument --depth 1 was missing when cloning CrackMapExec.

Turns out, there were other tools missing it (command below was run against the `dev` branch):

```
grep -rn clone * 2> /dev/null | grep git | grep -v depth | wc -l
20
```

To avoid any merge conflict, this PR must be merged after https://github.com/ThePorgs/Exegol-images/pull/177.
Indeed, I reproduced in this PR some of the changes brought by https://github.com/ThePorgs/Exegol-images/pull/177 and I added the modification to the comment I suggested.