### PR TITLE
Add zsh alias 'ws' to quickly change directory to the workspace

### DIFF
--- a/sources/assets/zsh/aliases
+++ b/sources/assets/zsh/aliases
@@ -6,3 +6,4 @@ alias urlencode='python -c "import sys, urllib as ul; print ul.quote_plus(sys.ar
 alias urldecode='python -c "import sys, urllib as ul; print ul.unquote_plus(sys.argv[1])"'
 alias sed-empty-line='sed /^$/d'
 alias http-put-server='python3 /opt/resources/linux/http-put-server.py --bind 0.0.0.0'
+alias ws='cd /workspace'


### PR DESCRIPTION
When doing an assessment, I found it painful to regularly have to type `cd /workspace`.
I ended up adding a simple zsh alias: `ws`

The goal was for the alias to be as simple as `cd`.

Unless there is another trick to efficiently go back to the workspace folder, I thought maybe other users would appreciate this simple contribution.