### PR TITLE
Reduce Docker layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Author: The Exegol Project
 
-FROM debian:11
+FROM debian:11-slim
 
 ARG TAG="local"
 ARG VERSION="local"
@@ -12,51 +12,45 @@ LABEL org.exegol.build_date="${BUILD_DATE}"
 LABEL org.exegol.app="Exegol"
 LABEL org.exegol.src_repository="https://github.com/ThePorgs/Exegol-images"
 
-RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
-
-ADD . sources /root/sources/
+COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-RUN chmod +x entrypoint.sh
-
-RUN ./entrypoint.sh package_base
-
 # WARNING: package_most_used can't be used with other functions other than: package_base, post_install_clean
-# RUN ./entrypoint.sh package_most_used
+# ./entrypoint.sh package_most_used
 
-# WARNING: the following installs (except: package_base, post_install_clean) can't be used with package_most_used
-RUN ./entrypoint.sh package_misc
-RUN ./entrypoint.sh package_misc_configure
-RUN ./entrypoint.sh package_c2
-RUN ./entrypoint.sh package_c2_configure
-RUN ./entrypoint.sh package_wordlists
-RUN ./entrypoint.sh package_wordlists_configure
-RUN ./entrypoint.sh package_cracking
-RUN ./entrypoint.sh package_cracking_configure
-RUN ./entrypoint.sh package_osint
-RUN ./entrypoint.sh package_osint_configure
-RUN ./entrypoint.sh package_web
-RUN ./entrypoint.sh package_web_configure
-RUN ./entrypoint.sh package_ad
-RUN ./entrypoint.sh package_ad_configure
-RUN ./entrypoint.sh package_mobile
-RUN ./entrypoint.sh package_iot
-RUN ./entrypoint.sh package_rfid
-RUN ./entrypoint.sh package_voip
-RUN ./entrypoint.sh package_sdr
-RUN ./entrypoint.sh package_network
-RUN ./entrypoint.sh package_wifi
-RUN ./entrypoint.sh package_forensic
-RUN ./entrypoint.sh package_cloud
-RUN ./entrypoint.sh package_steganography
-RUN ./entrypoint.sh package_reverse
-RUN ./entrypoint.sh package_crypto
-RUN ./entrypoint.sh package_code_analysis
-
-RUN ./entrypoint.sh post_install_clean
-
-RUN rm -rf /root/sources
+RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version && \
+    chmod +x entrypoint.sh && \
+    ./entrypoint.sh package_base && \
+    ./entrypoint.sh package_misc && \
+    ./entrypoint.sh package_misc_configure && \
+    ./entrypoint.sh package_c2 && \
+    ./entrypoint.sh package_c2_configure && \
+    ./entrypoint.sh package_wordlists && \
+    ./entrypoint.sh package_wordlists_configure && \
+    ./entrypoint.sh package_cracking && \
+    ./entrypoint.sh package_cracking_configure && \
+    ./entrypoint.sh package_osint && \
+    ./entrypoint.sh package_osint_configure && \
+    ./entrypoint.sh package_web && \
+    ./entrypoint.sh package_web_configure && \
+    ./entrypoint.sh package_ad && \
+    ./entrypoint.sh package_ad_configure && \
+    ./entrypoint.sh package_mobile && \
+    ./entrypoint.sh package_iot && \
+    ./entrypoint.sh package_rfid && \
+    ./entrypoint.sh package_voip && \
+    ./entrypoint.sh package_sdr && \
+    ./entrypoint.sh package_network && \
+    ./entrypoint.sh package_wifi && \
+    ./entrypoint.sh package_forensic && \
+    ./entrypoint.sh package_cloud && \
+    ./entrypoint.sh package_steganography && \
+    ./entrypoint.sh package_reverse && \
+    ./entrypoint.sh package_crypto && \
+    ./entrypoint.sh package_code_analysis && \
+    ./entrypoint.sh post_install_clean && \
+    rm -rf /root/sources /var/lib/apt/lists/*
 
 WORKDIR /workspace
 

--- a/ad.dockerfile
+++ b/ad.dockerfile
@@ -1,6 +1,6 @@
 # Author: The Exegol Project
 
-FROM debian:11
+FROM debian:11-slim
 
 ARG TAG="local"
 ARG VERSION="local"
@@ -12,34 +12,31 @@ LABEL org.exegol.build_date="${BUILD_DATE}"
 LABEL org.exegol.app="Exegol"
 LABEL org.exegol.src_repository="https://github.com/ThePorgs/Exegol-images"
 
-RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
-
-ADD . sources /root/sources/
+COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-RUN chmod +x entrypoint.sh
+# WARNING: package_most_used can't be used with other functions other than: package_base, post_install_clean
+# ./entrypoint.sh package_most_used
 
-RUN ./entrypoint.sh package_base
-
-# WARNING: the following installs (except: package_base, post_install_clean) can't be used with package_most_used
-RUN ./entrypoint.sh package_misc
-RUN ./entrypoint.sh package_misc_configure
-RUN ./entrypoint.sh package_c2
-RUN ./entrypoint.sh package_c2_configure
-RUN ./entrypoint.sh package_wordlists
-RUN ./entrypoint.sh package_wordlists_configure
-RUN ./entrypoint.sh package_cracking
-RUN ./entrypoint.sh package_cracking_configure
-RUN ./entrypoint.sh package_web
-RUN ./entrypoint.sh package_web_configure
-RUN ./entrypoint.sh package_ad
-RUN ./entrypoint.sh package_ad_configure
-RUN ./entrypoint.sh package_network
-
-RUN ./entrypoint.sh post_install_clean
-
-RUN rm -rf /root/sources
+RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version && \
+    chmod +x entrypoint.sh && \
+    ./entrypoint.sh package_base && \
+    ./entrypoint.sh package_misc && \
+    ./entrypoint.sh package_misc_configure && \
+    ./entrypoint.sh package_c2 && \
+    ./entrypoint.sh package_c2_configure && \
+    ./entrypoint.sh package_wordlists && \
+    ./entrypoint.sh package_wordlists_configure && \
+    ./entrypoint.sh package_cracking && \
+    ./entrypoint.sh package_cracking_configure && \
+    ./entrypoint.sh package_web && \
+    ./entrypoint.sh package_web_configure && \
+    ./entrypoint.sh package_ad && \
+    ./entrypoint.sh package_ad_configure && \
+    ./entrypoint.sh package_network
+    ./entrypoint.sh post_install_clean && \
+    rm -rf /root/sources /var/lib/apt/lists/*
 
 WORKDIR /workspace
 

--- a/debug.dockerfile
+++ b/debug.dockerfile
@@ -1,6 +1,6 @@
 # Author: The Exegol Project
 
-FROM debian:11
+FROM debian:11-slim
 
 ARG TAG="local"
 ARG VERSION="local"
@@ -12,19 +12,15 @@ LABEL org.exegol.build_date="${BUILD_DATE}"
 LABEL org.exegol.app="Exegol"
 LABEL org.exegol.src_repository="https://github.com/ThePorgs/Exegol-images"
 
-RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
-
-ADD . sources /root/sources/
+COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-RUN chmod +x entrypoint.sh
-
-RUN ./entrypoint.sh package_base_debug
-
-RUN ./entrypoint.sh post_install_clean
-
-RUN rm -rf /root/sources
+RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version && \
+    chmod +x entrypoint.sh && \
+    ./entrypoint.sh package_base_debug && \
+    ./entrypoint.sh post_install_clean && \
+    rm -rf /root/sources /var/lib/apt/lists/*
 
 WORKDIR /workspace
 

--- a/light.dockerfile
+++ b/light.dockerfile
@@ -1,6 +1,6 @@
 # Author: The Exegol Project
 
-FROM debian:11
+FROM debian:11-slim
 
 ARG TAG="local"
 ARG VERSION="local"
@@ -12,26 +12,21 @@ LABEL org.exegol.build_date="${BUILD_DATE}"
 LABEL org.exegol.app="Exegol"
 LABEL org.exegol.src_repository="https://github.com/ThePorgs/Exegol-images"
 
-RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
-
-ADD . sources /root/sources/
+COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-RUN chmod +x entrypoint.sh
-
-RUN ./entrypoint.sh package_base
-
 # WARNING: package_most_used can't be used with other functions other than: package_base, post_install_clean
-RUN ./entrypoint.sh package_most_used
+# ./entrypoint.sh package_most_used
 
-# WARNING: the following installs (except: package_base, post_install_clean) can't be used with package_most_used
-RUN ./entrypoint.sh package_misc
-RUN ./entrypoint.sh package_misc_configure
-
-RUN ./entrypoint.sh post_install_clean
-
-RUN rm -rf /root/sources
+RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version && \
+    chmod +x entrypoint.sh && \
+    ./entrypoint.sh package_base && \
+    ./entrypoint.sh package_most_used && \
+    ./entrypoint.sh package_misc && \
+    ./entrypoint.sh package_misc_configure && \
+    ./entrypoint.sh post_install_clean && \
+    rm -rf /root/sources /var/lib/apt/lists/*
 
 WORKDIR /workspace
 

--- a/osint.dockerfile
+++ b/osint.dockerfile
@@ -1,6 +1,6 @@
 # Author: The Exegol Project
 
-FROM debian:11
+FROM debian:11-slim
 
 ARG TAG="local"
 ARG VERSION="local"
@@ -12,25 +12,22 @@ LABEL org.exegol.build_date="${BUILD_DATE}"
 LABEL org.exegol.app="Exegol"
 LABEL org.exegol.src_repository="https://github.com/ThePorgs/Exegol-images"
 
-RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
-
-ADD . sources /root/sources/
+COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-RUN chmod +x entrypoint.sh
+# WARNING: package_most_used can't be used with other functions other than: package_base, post_install_clean
+# ./entrypoint.sh package_most_used
 
-RUN ./entrypoint.sh package_base
-
-# WARNING: the following installs (except: package_base, post_install_clean) can't be used with package_most_used
-RUN ./entrypoint.sh package_misc
-RUN ./entrypoint.sh package_misc_configure
-RUN ./entrypoint.sh package_osint
-RUN ./entrypoint.sh package_osint_configure
-
-RUN ./entrypoint.sh post_install_clean
-
-RUN rm -rf /root/sources
+RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version && \
+    chmod +x entrypoint.sh && \
+    ./entrypoint.sh package_base && \
+    ./entrypoint.sh package_misc && \
+    ./entrypoint.sh package_misc_configure && \
+    ./entrypoint.sh package_osint && \
+    ./entrypoint.sh package_osint_configure && \
+    ./entrypoint.sh post_install_clean && \
+    rm -rf /root/sources /var/lib/apt/lists/*
 
 WORKDIR /workspace
 

--- a/web.dockerfile
+++ b/web.dockerfile
@@ -1,6 +1,6 @@
 # Author: The Exegol Project
 
-FROM debian:11
+FROM debian:11-slim
 
 ARG TAG="local"
 ARG VERSION="local"
@@ -12,32 +12,29 @@ LABEL org.exegol.build_date="${BUILD_DATE}"
 LABEL org.exegol.app="Exegol"
 LABEL org.exegol.src_repository="https://github.com/ThePorgs/Exegol-images"
 
-RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
-
-ADD . sources /root/sources/
+COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-RUN chmod +x entrypoint.sh
+# WARNING: package_most_used can't be used with other functions other than: package_base, post_install_clean
+# ./entrypoint.sh package_most_used
 
-RUN ./entrypoint.sh package_base
-
-# WARNING: the following installs (except: package_base, post_install_clean) can't be used with package_most_used
-RUN ./entrypoint.sh package_misc
-RUN ./entrypoint.sh package_misc_configure
-RUN ./entrypoint.sh package_wordlists
-RUN ./entrypoint.sh package_wordlists_configure
-RUN ./entrypoint.sh package_cracking
-RUN ./entrypoint.sh package_cracking_configure
-RUN ./entrypoint.sh package_osint
-RUN ./entrypoint.sh package_osint_configure
-RUN ./entrypoint.sh package_web
-RUN ./entrypoint.sh package_web_configure
-RUN ./entrypoint.sh package_code_analysis
-
-RUN ./entrypoint.sh post_install_clean
-
-RUN rm -rf /root/sources
+RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version && \
+    chmod +x entrypoint.sh && \
+    ./entrypoint.sh package_base && \
+    ./entrypoint.sh package_misc && \
+    ./entrypoint.sh package_misc_configure && \
+    ./entrypoint.sh package_wordlists && \
+    ./entrypoint.sh package_wordlists_configure && \
+    ./entrypoint.sh package_cracking && \
+    ./entrypoint.sh package_cracking_configure && \
+    ./entrypoint.sh package_osint && \
+    ./entrypoint.sh package_osint_configure && \
+    ./entrypoint.sh package_web && \
+    ./entrypoint.sh package_web_configure && \
+    ./entrypoint.sh package_code_analysis && \
+    ./entrypoint.sh post_install_clean && \
+    rm -rf /root/sources /var/lib/apt/lists/*
 
 WORKDIR /workspace
 


### PR DESCRIPTION
1/ As mentionned in https://github.com/ThePorgs/Exegol-images/issues/96, this PR aims at reducing the number of layers of the Docker images for better performance, reduced image size and to remove potential caching quirks. To do so, the RUN calls are merged into one as recommended by [Docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/).

For example, the released image full-3.0.2 has 28 layers. By reducing it to 4 layers, the new image is 0.9GB smaller.

2/ In addition, the image is based from `debian:11-slim` rather than `debian:11`. Any extra necessary packages to build the image will be pulled from Debian's repositories anyway.

3/ Finally, the apt cache files are removed from the image. There is no need to ship an image with outdated package lists.
