### PR TITLE
Clean rusthound

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -788,6 +788,8 @@ function install_rusthound() {
     # Sourcing rustup shell setup, so that rust binaries are found when installing cme
     source "$HOME/.cargo/env"
     cargo build --release
+    # Clean dependencies used to build the binary
+    rm -rf target/release/{deps,build}
     ln -s /opt/tools/RustHound/target/release/rusthound /opt/tools/bin/rusthound
     add-history rusthound
     add-test-command "rusthound --help"


### PR DESCRIPTION
# Description

Remove the dependencies used while compiling rusthound. Once the binary has been built these dependencies are not longer used.
Cleaning these two folders would free 729M of disk usage.

