### PR TITLE
[my-resources] Remove any bqm temporary file for Bloodhound

### DIFF
--- a/sources/assets/exegol/load_supported_setups.sh
+++ b/sources/assets/exegol/load_supported_setups.sh
@@ -171,6 +171,9 @@ function deploy_bloodhound() {
 
   deploy_bloodhound_config
 
+  # Clean up any unlikely pre-existing file to avoid bqm prompts
+  [[ -f "$bqm_output_file" ]] && rm -f "$bqm_output_file"
+
   # If a user places Bloodhound json files in both folders merge and replacement,
   # replacement must be executed last to only keep the output of replacement.
   deploy_bloodhound_customqueries_merge


### PR DESCRIPTION
# Description

In the unlikely event that a temporary bqm file exists prior to running the tool itself, this PR removes the tempfile.
I don't think this case should ever happen, but better safe than sorry.