### PR TITLE
Rename Bloodhound customqueries categories

### DIFF
--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -2,7 +2,7 @@
     "queries": [
         {
             "name": "Owned objects",
-            "category": "Tigers love pepper",
+            "category": "Owned Objects",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (m) WHERE m.owned=TRUE RETURN m"
@@ -10,7 +10,7 @@
         },
         {
             "name": "Direct groups of owned users",
-            "category": "Tigers love pepper",
+            "category": "Owned Objects",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (u:User {owned:true}), (g:Group), p=(u)-[:MemberOf]->(g) RETURN p",
@@ -20,7 +20,7 @@
         },
         {
             "name": "Unrolled groups of owned users",
-            "category": "Tigers love pepper",
+            "category": "Owned Objects",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (m:User) WHERE m.owned=TRUE WITH m MATCH p=(m)-[:MemberOf*1..]->(n:Group) RETURN p"
@@ -28,7 +28,7 @@
         },
         {
             "name": "Shortest paths from owned objects to High Value Targets (5 hops)",
-            "category": "Tigers love pepper",
+            "category": "Owned Objects",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p=shortestPath((n {owned:true})-[:MemberOf|HasSession|AdminTo|AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|CanRDP|ExecuteDCOM|AllowedToDelegate|ReadLAPSPassword|Contains|GpLink|AddAllowedToAct|AllowedToAct|SQLAdmin|ReadGMSAPassword|HasSIDHistory|CanPSRemote*1..5]->(m {highvalue:true})) WHERE NOT n=m RETURN p",
@@ -37,7 +37,7 @@
         },
         {
             "name": "Most exploitable paths from owned objects to High Value Targets (5 hops)",
-            "category": "Tigers love pepper",
+            "category": "Owned Objects",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p=allShortestPaths((n {owned:true})-[:MemberOf|AdminTo|AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|ExecuteDCOM|AllowedToDelegate|ReadLAPSPassword|Contains|GpLink|AddAllowedToAct|AllowedToAct|SQLAdmin|ReadGMSAPassword|HasSIDHistory*1..5]->(m {highvalue:true})) WHERE NOT n=m RETURN p",
@@ -46,7 +46,7 @@
         },
         {
             "name": "Next steps (5 hops) from owned objects",
-            "category": "Tigers love pepper",
+            "category": "Owned Objects",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p=shortestPath((c {owned: true})-[*1..5]->(s)) WHERE NOT c = s RETURN p"
@@ -54,15 +54,23 @@
         },
         {
             "name": "Next steps (3 hops) from owned objects",
-            "category": "Tigers love pepper",
+            "category": "Owned Objects",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p=shortestPath((c {owned: true})-[*1..3]->(s)) WHERE NOT c = s RETURN p"
             }]
         },
         {
+            "name": "Owned users with permissions against GPOs",
+            "category": "Owned Objects",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(u:User {owned:true})-[r:AllExtendedRights|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|GpLink*1..]->(g:GPO) RETURN p"
+            }]
+        },
+        {
             "name": "Connections between different domains/forests",
-            "category": "Tigers love pepper",
+            "category": "Domains/Forests",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p = (a)-[r]->(b) WHERE NOT a.domain = b.domain RETURN p"
@@ -70,300 +78,15 @@
         },
         {
             "name": "Connections (ACEs only) between different domains/forests",
-            "category": "Tigers love pepper",
+            "category": "Domains/Forests",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p = (a)-[r]->(b) WHERE NOT a.domain = b.domain AND r.isacl = True RETURN p"
             }]
         },
         {
-            "name": "Owned users with permissions against GPOs",
-            "category": "Tigers love pepper",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p=(u:User {owned:true})-[r:AllExtendedRights|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|GpLink*1..]->(g:GPO) RETURN p"
-            }]
-        },
-        {
-            "name": "Kerberoastable users with a path to DA",
-            "category": "They hate cinnamon",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (u:User {hasspn:true}) MATCH (g:Group) WHERE g.objectid ENDS WITH '-512' MATCH p = shortestPath( (u)-[*1..]->(g) ) RETURN p"
-            }]
-        },
-        {
-            "name": "Kerberoastable users with a path to High Value",
-            "category": "They hate cinnamon",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (u:User {hasspn:true}),(n {highvalue:true}),p = shortestPath( (u)-[*1..]->(n) ) RETURN p"
-            }]
-        },
-        {
-            "name": " Kerberoastable users and where they are AdminTo",
-            "category": "They hate cinnamon",
-            "queryList": [{
-                "final": true,
-                "query": "OPTIONAL MATCH (u:User) WHERE u.hasspn=true OPTIONAL MATCH (u)-[r:AdminTo]->(c:Computer) RETURN u"
-            }]
-        },
-        {
-            "name": "Kerberoastable users who are members of high value groups",
-            "category": "They hate cinnamon",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (u:User)-[r:MemberOf*1..]->(g:Group) WHERE g.highvalue=true AND u.hasspn=true RETURN u"
-            }]
-        },
-        {
-            "name": "Kerberoastable users with passwords last set > 5 years ago",
-            "category": "They hate cinnamon",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (u:User) WHERE n.hasspn=true AND WHERE u.pwdlastset < (datetime().epochseconds - (1825 * 86400)) and NOT u.pwdlastset IN [-1.0, 0.0] RETURN u"
-            }]
-        },
-        {
-            "name": "Kerberoastable Users",
-            "category": "They hate cinnamon",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (n:User)WHERE n.hasspn=true RETURN n",
-                "allowCollapse": false
-            }]
-        },
-        {
-            "name": "AS-REProastable Users",
-            "category": "They hate cinnamon",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (u:User {dontreqpreauth: true}) RETURN u"
-            }]
-        },
-        {
-            "name": "Unconstrained Delegations",
-            "category": "Ready to let the dogs out?",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (c {unconstraineddelegation:true}) return c"
-            }]
-        },
-        {
-            "name": "Constrained Delegations (with Protocol Transition)",
-            "category": "Ready to let the dogs out?",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (c) WHERE NOT c.allowedtodelegate IS NULL AND c.trustedtoauth=true return c"
-            }]
-        },
-        {
-            "name": "Constrained Delegations (without Protocol Transition)",
-            "category": "Ready to let the dogs out?",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (c) WHERE NOT c.allowedtodelegate IS NULL AND c.trustedtoauth=false return c"
-            }]
-        },
-        {
-            "name": "Resource-Based Constrained Delegations",
-            "category": "Ready to let the dogs out?",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p=(u)-[:AllowedToAct]->(c) RETURN p"
-            }]
-        },
-        {
-            "name": "Unconstrained Delegation systems (without domain controllers)",
-            "category": "Ready to let the dogs out?",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (c1:Computer)-[:MemberOf*1..]->(g:Group) WHERE g.objectid ENDS WITH '-516' WITH COLLECT(c1.name) AS domainControllers MATCH (c2 {unconstraineddelegation:true}) WHERE NOT c2.name IN domainControllers RETURN c2"
-            }]
-        },
-        {
-            "name": "(Warning: edits the DB) Mark unconstrained delegation systems as high value targets",
-            "category": "Ready to let the dogs out?",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (c1:Computer)-[:MemberOf*1..]->(g:Group) WHERE g.objectid ENDS WITH '-516' WITH COLLECT(c1.name) AS domainControllers MATCH (c2 {unconstraineddelegation:true}) WHERE NOT c2.name IN domainControllers SET c2.highvalue = true RETURN c2"
-            }]
-        },
-        {
-            "name": "Shortest paths from owned principals to unconstrained delegation systems",
-            "category": "Ready to let the dogs out?",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (n {owned:true}) MATCH p=shortestPath((n)-[:MemberOf|HasSession|AdminTo|AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|ExecuteDCOM|AllowedToDelegate|ReadLAPSPassword|Contains|GpLink|AddAllowedToAct|AllowedToAct|SQLAdmin|ReadGMSAPassword|HasSIDHistory|CanPSRemote*1..]->(m:Computer {unconstraineddelegation: true})) WHERE NOT n=m RETURN p"
-            }]
-        },
-        {
-            "name": "Find computers admin to other computers",
-            "category": "A nerdy hillbilly",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p = (c1:Computer)-[r1:AdminTo]->(c2:Computer) RETURN p UNION ALL MATCH p = (c3:Computer)-[r2:MemberOf*1..]->(g:Group)-[r3:AdminTo]->(c4:Computer) RETURN p"
-            }]
-        },
-        {
-            "name": "Logged in Admins",
-            "category": "A nerdy hillbilly",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p=(a:Computer)-[r:HasSession]->(b:User) WITH a,b,r MATCH p=shortestPath((b)-[:AdminTo|MemberOf*1..]->(a)) RETURN p",
-                "allowCollapse": true
-            }]
-        },
-        {
-            "name": "Users with local admin rights",
-            "category": "A nerdy hillbilly",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p=(m:User)-[r:AdminTo]->(n:Computer) RETURN p"
-            }]
-        },
-        {
-            "name": "Domain admin sessions",
-            "category": "A nerdy hillbilly",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (n:User)-[:MemberOf]->(g:Group) WHERE g.objectid ENDS WITH '-512' MATCH p = (c:Computer)-[:HasSession]->(n) return p"
-            }]
-        },
-        {
-            "name": "Users with adminCount, not sensitive for delegation, not members of Protected Users",
-            "category": "A nerdy hillbilly",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (u)-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ \"(?i)S-1-5-.*-525\" WITH COLLECT (u.name) as protectedUsers MATCH p=(u2:User)-[:MemberOf*1..3]->(g2:Group) WHERE u2.admincount=true AND u2.sensitive=false AND NOT u2.name IN protectedUsers RETURN p"
-            }]
-        },
-        {
-            "name": "Objects with the AddAllowedToAct or WriteAccountRestrictions right on a computer",
-            "category": "A nerdy hillbilly",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p=(g)-[:AddAllowedToAct|WriteAccountRestrictions]->(c:Computer) RETURN p"
-            }]
-        },
-        {
-            "name": "Groups that contain the word 'admin'",
-            "category": "A one-man wolf pack",
-            "queryList": [{
-                "final": true,
-                "query": "Match (n:Group) WHERE n.name CONTAINS 'ADMIN' RETURN n"
-            }]
-        },
-        {
-            "name": "Groups that can change user passwords",
-            "category": "A one-man wolf pack",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p=(m:Group)-[r:ForceChangePassword]->(n:User) RETURN DISTINCT m[.]name,  COUNT(m[.]name) ORDER BY COUNT(m[.]name) DESC"
-            }]
-        },
-        {
-            "name": "Groups of High Value Targets",
-            "category": "A one-man wolf pack",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p=(n:User)-[r:MemberOf*1..]->(m:Group {highvalue:true}) RETURN p"
-            }]
-        },
-        {
-            "name": "Non Admin Groups with High Value Privileges",
-            "category": "A one-man wolf pack",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p=(g:Group)-[r:Owns|:WriteDacl|:GenericAll|:WriteOwner|:ExecuteDCOM|:GenericWrite|:AllowedToDelegate|:ForceChangePassword]->(n:Computer) WHERE NOT g.name CONTAINS 'ADMIN' RETURN p",
-                "allowCollapse": true
-            }]
-        },
-        {
-            "name": "Groups with Computer and User Objects",
-            "category": "A one-man wolf pack",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (c:Computer)-[r:MemberOf*1..]->(groupsWithComps:Group) WITH groupsWithComps MATCH (u:User)-[r:MemberOf*1..]->(groupsWithComps) RETURN DISTINCT(groupsWithComps) as groupsWithCompsAndUsers",
-                "allowCollapse": true,
-                "endNode": "{}"
-            }]
-        },
-        {
-            "name": "Groups that can reset passwords (Warning: Heavy)",
-            "category": "A one-man wolf pack",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p=(m:Group)-[r:ForceChangePassword]->(n:User) RETURN p"
-            }]
-        },
-        {
-            "name": "Groups that have local admin rights (Warning: Heavy)",
-            "category": "A one-man wolf pack",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p=(m:Group)-[r:AdminTo]->(n:Computer) RETURN p"
-            }]
-        },
-        {
-            "name": "Users never logged on and account still active",
-            "category": "There are skittles in there!",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (n:User) WHERE n.lastlogontimestamp=-1.0 AND n.enabled=TRUE RETURN n "
-            }]
-        },
-        {
-            "name": "Users logged in the last 90 days",
-            "category": "There are skittles in there!",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (u:User) WHERE u.lastlogon < (datetime().epochseconds - (90 * 86400)) and NOT u.lastlogon IN [-1.0, 0.0] RETURN u"
-            }]
-        },
-        {
-            "name": "Users with passwords last set in the last 90 days",
-            "category": "There are skittles in there!",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (u:User) WHERE u.pwdlastset < (datetime().epochseconds - (90 * 86400)) and NOT u.pwdlastset IN [-1.0, 0.0] RETURN u"
-            }]
-        },
-        {
-            "name": "Find if unprivileged users have rights to add members into groups",
-            "category": "There are skittles in there!",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (n:User {admincount:False}) MATCH p=allShortestPaths((n)-[r:AddMember*1..]->(m:Group)) RETURN p"
-            }]
-        },
-        {
-            "name": "Find all users a part of the VPN group",
-            "category": "There are skittles in there!",
-            "queryList": [{
-                "final": true,
-                "query": "Match p=(u:User)-[:MemberOf]->(g:Group) WHERE toUPPER (g.name) CONTAINS 'VPN' return p"
-            }]
-        },
-        {
-            "name": "View all GPOs",
-            "category": "There are skittles in there!",
-            "queryList": [{
-                "final": true,
-                "query": "Match (n:GPO) RETURN n"
-            }]
-        },
-        {
-            "name": "Find if any domain user has interesting permissions against a GPO (Warning: Heavy)",
-            "category": "There are skittles in there!",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p=(u:User)-[r:AllExtendedRights|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|GpLink*1..]->(g:GPO) RETURN p"
-            }]
-        },
-        {
             "name": "Can a user from domain ‘A ‘ do anything to any computer in domain ‘B’ (Warning: VERY Heavy)",
-            "category": "There are skittles in there!",
+            "category": "Domains/Forests",
             "queryList": [{
                     "final": false,
                     "title": "Select source domain...",
@@ -383,8 +106,285 @@
             ]
         },
         {
+            "name": "Kerberoastable users with a path to DA",
+            "category": "Roasting",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (u:User {hasspn:true}) MATCH (g:Group) WHERE g.objectid ENDS WITH '-512' MATCH p = shortestPath( (u)-[*1..]->(g) ) RETURN p"
+            }]
+        },
+        {
+            "name": "Kerberoastable users with a path to High Value",
+            "category": "Roasting",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (u:User {hasspn:true}),(n {highvalue:true}),p = shortestPath( (u)-[*1..]->(n) ) RETURN p"
+            }]
+        },
+        {
+            "name": " Kerberoastable users and where they are AdminTo",
+            "category": "Roasting",
+            "queryList": [{
+                "final": true,
+                "query": "OPTIONAL MATCH (u:User) WHERE u.hasspn=true OPTIONAL MATCH (u)-[r:AdminTo]->(c:Computer) RETURN u"
+            }]
+        },
+        {
+            "name": "Kerberoastable users who are members of high value groups",
+            "category": "Roasting",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (u:User)-[r:MemberOf*1..]->(g:Group) WHERE g.highvalue=true AND u.hasspn=true RETURN u"
+            }]
+        },
+        {
+            "name": "Kerberoastable users with passwords last set > 5 years ago",
+            "category": "Roasting",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (u:User) WHERE n.hasspn=true AND WHERE u.pwdlastset < (datetime().epochseconds - (1825 * 86400)) and NOT u.pwdlastset IN [-1.0, 0.0] RETURN u"
+            }]
+        },
+        {
+            "name": "Kerberoastable Users",
+            "category": "Roasting",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (n:User)WHERE n.hasspn=true RETURN n",
+                "allowCollapse": false
+            }]
+        },
+        {
+            "name": "AS-REProastable Users",
+            "category": "Roasting",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (u:User {dontreqpreauth: true}) RETURN u"
+            }]
+        },
+        {
+            "name": "Unconstrained Delegations",
+            "category": "Kerberos Delegations",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (c {unconstraineddelegation:true}) return c"
+            }]
+        },
+        {
+            "name": "Constrained Delegations (with Protocol Transition)",
+            "category": "Kerberos Delegations",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (c) WHERE NOT c.allowedtodelegate IS NULL AND c.trustedtoauth=true return c"
+            }]
+        },
+        {
+            "name": "Constrained Delegations (without Protocol Transition)",
+            "category": "Kerberos Delegations",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (c) WHERE NOT c.allowedtodelegate IS NULL AND c.trustedtoauth=false return c"
+            }]
+        },
+        {
+            "name": "Resource-Based Constrained Delegations",
+            "category": "Kerberos Delegations",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(u)-[:AllowedToAct]->(c) RETURN p"
+            }]
+        },
+        {
+            "name": "Unconstrained Delegation systems (without domain controllers)",
+            "category": "Kerberos Delegations",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (c1:Computer)-[:MemberOf*1..]->(g:Group) WHERE g.objectid ENDS WITH '-516' WITH COLLECT(c1.name) AS domainControllers MATCH (c2 {unconstraineddelegation:true}) WHERE NOT c2.name IN domainControllers RETURN c2"
+            }]
+        },
+        {
+            "name": "(Warning: edits the DB) Mark unconstrained delegation systems as high value targets",
+            "category": "Kerberos Delegations",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (c1:Computer)-[:MemberOf*1..]->(g:Group) WHERE g.objectid ENDS WITH '-516' WITH COLLECT(c1.name) AS domainControllers MATCH (c2 {unconstraineddelegation:true}) WHERE NOT c2.name IN domainControllers SET c2.highvalue = true RETURN c2"
+            }]
+        },
+        {
+            "name": "Shortest paths from owned principals to unconstrained delegation systems",
+            "category": "Kerberos Delegations",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (n {owned:true}) MATCH p=shortestPath((n)-[:MemberOf|HasSession|AdminTo|AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|ExecuteDCOM|AllowedToDelegate|ReadLAPSPassword|Contains|GpLink|AddAllowedToAct|AllowedToAct|SQLAdmin|ReadGMSAPassword|HasSIDHistory|CanPSRemote*1..]->(m:Computer {unconstraineddelegation: true})) WHERE NOT n=m RETURN p"
+            }]
+        },
+        {
+            "name": "Find computers admin to other computers",
+            "category": "Admins",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p = (c1:Computer)-[r1:AdminTo]->(c2:Computer) RETURN p UNION ALL MATCH p = (c3:Computer)-[r2:MemberOf*1..]->(g:Group)-[r3:AdminTo]->(c4:Computer) RETURN p"
+            }]
+        },
+        {
+            "name": "Logged in Admins",
+            "category": "Admins",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(a:Computer)-[r:HasSession]->(b:User) WITH a,b,r MATCH p=shortestPath((b)-[:AdminTo|MemberOf*1..]->(a)) RETURN p",
+                "allowCollapse": true
+            }]
+        },
+        {
+            "name": "Users with local admin rights",
+            "category": "Admins",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(m:User)-[r:AdminTo]->(n:Computer) RETURN p"
+            }]
+        },
+        {
+            "name": "Domain admin sessions",
+            "category": "Admins",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (n:User)-[:MemberOf]->(g:Group) WHERE g.objectid ENDS WITH '-512' MATCH p = (c:Computer)-[:HasSession]->(n) return p"
+            }]
+        },
+        {
+            "name": "Users with adminCount, not sensitive for delegation, not members of Protected Users",
+            "category": "Admins",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (u)-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ \"(?i)S-1-5-.*-525\" WITH COLLECT (u.name) as protectedUsers MATCH p=(u2:User)-[:MemberOf*1..3]->(g2:Group) WHERE u2.admincount=true AND u2.sensitive=false AND NOT u2.name IN protectedUsers RETURN p"
+            }]
+        },
+        {
+            "name": "Objects with the AddAllowedToAct or WriteAccountRestrictions right on a computer",
+            "category": "Admins",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(g)-[:AddAllowedToAct|WriteAccountRestrictions]->(c:Computer) RETURN p"
+            }]
+        },
+        {
+            "name": "Groups that contain the word 'admin'",
+            "category": "Groups",
+            "queryList": [{
+                "final": true,
+                "query": "Match (n:Group) WHERE n.name CONTAINS 'ADMIN' RETURN n"
+            }]
+        },
+        {
+            "name": "Groups that can change user passwords",
+            "category": "Groups",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(m:Group)-[r:ForceChangePassword]->(n:User) RETURN DISTINCT m[.]name,  COUNT(m[.]name) ORDER BY COUNT(m[.]name) DESC"
+            }]
+        },
+        {
+            "name": "Groups of High Value Targets",
+            "category": "Groups",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(n:User)-[r:MemberOf*1..]->(m:Group {highvalue:true}) RETURN p"
+            }]
+        },
+        {
+            "name": "Non Admin Groups with High Value Privileges",
+            "category": "Groups",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(g:Group)-[r:Owns|:WriteDacl|:GenericAll|:WriteOwner|:ExecuteDCOM|:GenericWrite|:AllowedToDelegate|:ForceChangePassword]->(n:Computer) WHERE NOT g.name CONTAINS 'ADMIN' RETURN p",
+                "allowCollapse": true
+            }]
+        },
+        {
+            "name": "Groups with Computer and User Objects",
+            "category": "Groups",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (c:Computer)-[r:MemberOf*1..]->(groupsWithComps:Group) WITH groupsWithComps MATCH (u:User)-[r:MemberOf*1..]->(groupsWithComps) RETURN DISTINCT(groupsWithComps) as groupsWithCompsAndUsers",
+                "allowCollapse": true,
+                "endNode": "{}"
+            }]
+        },
+        {
+            "name": "Groups that can reset passwords (Warning: Heavy)",
+            "category": "Groups",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(m:Group)-[r:ForceChangePassword]->(n:User) RETURN p"
+            }]
+        },
+        {
+            "name": "Groups that have local admin rights (Warning: Heavy)",
+            "category": "Groups",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(m:Group)-[r:AdminTo]->(n:Computer) RETURN p"
+            }]
+        },
+        {
+            "name": "Users never logged on and account still active",
+            "category": "Users",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (n:User) WHERE n.lastlogontimestamp=-1.0 AND n.enabled=TRUE RETURN n "
+            }]
+        },
+        {
+            "name": "Users logged in the last 90 days",
+            "category": "Users",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (u:User) WHERE u.lastlogon < (datetime().epochseconds - (90 * 86400)) and NOT u.lastlogon IN [-1.0, 0.0] RETURN u"
+            }]
+        },
+        {
+            "name": "Users with passwords last set in the last 90 days",
+            "category": "Users",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (u:User) WHERE u.pwdlastset < (datetime().epochseconds - (90 * 86400)) and NOT u.pwdlastset IN [-1.0, 0.0] RETURN u"
+            }]
+        },
+        {
+            "name": "Find if unprivileged users have rights to add members into groups",
+            "category": "Users",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (n:User {admincount:False}) MATCH p=allShortestPaths((n)-[r:AddMember*1..]->(m:Group)) RETURN p"
+            }]
+        },
+        {
+            "name": "Find all users a part of the VPN group",
+            "category": "Users",
+            "queryList": [{
+                "final": true,
+                "query": "Match p=(u:User)-[:MemberOf]->(g:Group) WHERE toUPPER (g.name) CONTAINS 'VPN' return p"
+            }]
+        },
+        {
+            "name": "View all GPOs",
+            "category": "GPOs",
+            "queryList": [{
+                "final": true,
+                "query": "Match (n:GPO) RETURN n"
+            }]
+        },
+        {
+            "name": "Find if any domain user has interesting permissions against a GPO (Warning: Heavy)",
+            "category": "GPOs",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(u:User)-[r:AllExtendedRights|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|GpLink*1..]->(g:GPO) RETURN p"
+            }]
+        },
+        {
             "name": "Find all computers running with Windows XP",
-            "category": "It’s not illegal. It’s frowned upon",
+            "category": "Outdated OS",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (c:Computer) WHERE toUpper(c.operatingsystem) CONTAINS 'XP' RETURN c"
@@ -392,7 +392,7 @@
         },
         {
             "name": "Find all computers running with Windows 2000",
-            "category": "It’s not illegal. It’s frowned upon",
+            "category": "Outdated OS",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (c:Computer) WHERE toUpper(c.operatingsystem) CONTAINS '2000' RETURN c"
@@ -400,7 +400,7 @@
         },
         {
             "name": "Find all computers running with Windows 2003",
-            "category": "It’s not illegal. It’s frowned upon",
+            "category": "Outdated OS",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (c:Computer) WHERE toUpper(c.operatingsystem) CONTAINS '2003' RETURN c"
@@ -408,7 +408,7 @@
         },
         {
             "name": "Find all computers running with Windows 2008",
-            "category": "It’s not illegal. It’s frowned upon",
+            "category": "Outdated OS",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (c:Computer) WHERE toUpper(c.operatingsystem) CONTAINS '2008' RETURN c"
@@ -416,7 +416,7 @@
         },
         {
             "name": "Find all computers running with Windows Vista",
-            "category": "It’s not illegal. It’s frowned upon",
+            "category": "Outdated OS",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (c:Computer) WHERE toUpper(c.operatingsystem) CONTAINS 'VISTA' RETURN c"
@@ -424,7 +424,7 @@
         },
         {
             "name": "Find all computers running with Windows 7",
-            "category": "It’s not illegal. It’s frowned upon",
+            "category": "Outdated OS",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (c:Computer) WHERE toUpper(c.operatingsystem) CONTAINS '7' RETURN c"
@@ -432,7 +432,7 @@
         },
         {
             "name": "Top Ten Users with Most Sessions",
-            "category": "Not at the table Carlos!",
+            "category": "Top Ten",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (n:User),(m:Computer), (n)<-[r:HasSession]-(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH n, count(r) as rel_count order by rel_count desc LIMIT 10 MATCH p=(m)-[r:HasSession]->(n) RETURN p",
@@ -441,7 +441,7 @@
         },
         {
             "name": "Top Ten Computers with Most Sessions",
-            "category": "Not at the table Carlos!",
+            "category": "Top Ten",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (n:User),(m:Computer), (n)<-[r:HasSession]-(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) as rel_count order by rel_count desc LIMIT 10 MATCH p=(m)-[r:HasSession]->(n) RETURN p",
@@ -450,7 +450,7 @@
         },
         {
             "name": "Top Ten Users with Most Local Admin Rights",
-            "category": "Not at the table Carlos!",
+            "category": "Top Ten",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH n, count(r) as rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) RETURN p",
@@ -459,7 +459,7 @@
         },
         {
             "name": "Top Ten Computers with Most Admins and their admins",
-            "category": "Not at the table Carlos!",
+            "category": "Top Ten",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) as rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) RETURN p",
@@ -468,7 +468,7 @@
         },
         {
             "name": "Top Ten Computers with Most Admins",
-            "category": "Not at the table Carlos!",
+            "category": "Top Ten",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) as rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) RETURN m",
@@ -477,7 +477,7 @@
         },
         {
             "name": "(Warning: edits the DB) Mark Top Ten Computers with Most Admins as HVT",
-            "category": "Not at the table Carlos!",
+            "category": "Top Ten",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) as rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) SET m.highvalue = true RETURN m",
@@ -486,7 +486,7 @@
         },
                 {
             "name": "Top 20 nodes with most first degree object controls",
-            "category": "Not at the table Carlos!",
+            "category": "Top Ten",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p=(u)-[r1]->(n) WHERE r1.isacl = true WITH u, count(r1) AS count_ctrl ORDER BY count_ctrl DESC LIMIT 20 RETURN u",
@@ -494,8 +494,8 @@
             }]
         },
                 {
-            "name": "Top ten nodes with most group delegated object controls",
-            "category": "Not at the table Carlos!",
+            "name": "Top Ten nodes with most group delegated object controls",
+            "category": "Top Ten",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p=(u)-[r1:MemberOf*1..]->(g:Group)-[r2]->(n) WHERE r2.isacl=true WITH u, count(r2) AS count_ctrl ORDER BY count_ctrl DESC LIMIT 20 RETURN u",
@@ -504,7 +504,7 @@
         },
         {
             "name": "Find machines Domain Users can RDP into",
-            "category": "We can’t find Doug",
+            "category": "RDP",
             "queryList": [{
                 "final": true,
                 "query": "match p=(g:Group)-[:CanRDP]->(c:Computer) where g.objectid ENDS WITH '-513' return p"
@@ -512,7 +512,7 @@
         },
         {
             "name": "Find Servers Domain Users can RDP To",
-            "category": "We can’t find Doug",
+            "category": "RDP",
             "queryList": [{
                 "final": true,
                 "query": "match p=(g:Group)-[:CanRDP]->(c:Computer) where g.name STARTS WITH 'DOMAIN USERS' AND c.operatingsystem CONTAINS 'Server' return p",
@@ -521,7 +521,7 @@
         },
         {
             "name": "Find what groups can RDP",
-            "category": "We can’t find Doug",
+            "category": "RDP",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p=(m:Group)-[r:CanRDP]->(n:Computer) RETURN p"
@@ -529,7 +529,7 @@
         },
         {
             "name": "Return All Azure Users that are part of the ‘Global Administrator’ Role",
-            "category": "It's called a satchel",
+            "category": "Azure",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p =(n)-[r:AZGlobalAdmin*1..]->(m) RETURN p"
@@ -537,7 +537,7 @@
         },
         {
             "name": "Return All On-Prem users with edges to Azure",
-            "category": "It's called a satchel",
+            "category": "Azure",
             "queryList": [{
                 "final": true,
                 "query": "MATCH  p=(m:User)-[r:AZResetPassword|AZOwns|AZUserAccessAdministrator|AZContributor|AZAddMembers|AZGlobalAdmin|AZVMContributor|AZOwnsAZAvereContributor]->(n) WHERE m.objectid CONTAINS 'S-1-5-21' RETURN p"
@@ -545,7 +545,7 @@
         },
         {
             "name": "Find all paths to an Azure VM",
-            "category": "It's called a satchel",
+            "category": "Azure",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p = (n)-[r]->(g:AZVM) RETURN p"
@@ -553,7 +553,7 @@
         },
         {
             "name": "Find all paths to an Azure KeyVault",
-            "category": "It's called a satchel",
+            "category": "Azure",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p = (n)-[r]->(g:AZKeyVault) RETURN p"
@@ -561,7 +561,7 @@
         },
         {
             "name": "Return All Azure Users and their Groups",
-            "category": "It's called a satchel",
+            "category": "Azure",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p=(m:AZUser)-[r:MemberOf]->(n) WHERE NOT m.objectid CONTAINS 'S-1-5' RETURN p"
@@ -569,7 +569,7 @@
         },
         {
             "name": "Return All Azure AD Groups that are synchronized with On-Premise AD",
-            "category": "It's called a satchel",
+            "category": "Azure",
             "queryList": [{
                 "final": true,
                 "query": "MATCH (n:Group) WHERE n.objectid CONTAINS 'S-1-5' AND n.azsyncid IS NOT NULL RETURN n"
@@ -577,7 +577,7 @@
         },
         {
             "name": "Find all Privileged Service Principals",
-            "category": "It's called a satchel",
+            "category": "Azure",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p = (g:AZServicePrincipal)-[r]->(n) RETURN p"
@@ -585,7 +585,7 @@
         },
         {
             "name": "Find all Owners of Azure Applications",
-            "category": "It's called a satchel",
+            "category": "Azure",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p = (n)-[r:AZOwns]->(g:AZApp) RETURN p"
@@ -740,7 +740,7 @@
             }]
         },
         {
-			"name": "Find users that can RDP into something",
+			"name": "Find users with a plaintext attribute that can RDP into something",
 			"category": "PlainText Password Queries",
 			"queryList": [
 				{
@@ -751,7 +751,7 @@
 			]
 		},
 		{
-			"name": "Find users that belong to high value groups",
+			"name": "Find users with a plaintext attribute that belong to high value groups",
 			"category": "PlainText Password Queries",
 			"queryList": [
 				{
@@ -762,7 +762,7 @@
 			]
 		},
 		{
-			"name": "Find kerberoastable users",
+			"name": "Find users with a plaintext attribute that are kerberoastable",
 			"category": "PlainText Password Queries",
 			"queryList": [
 				{


### PR DESCRIPTION
# Description

Following @ShutdownRepo's advice in https://github.com/ThePorgs/Exegol-images/pull/163, this PR aims at reorganizing a bit the categories for Exegol's Bloodhound customqueries.json file.

Even if it's mainly a renaming, I also added some new categories, which implied to move around a few queries.

Any thoughts?

Remark: this PR is the same as https://github.com/ThePorgs/Exegol-images/pull/208. The difference is that it is `based on the branch 3.1.1` instead of dev, and `Kerberoasting was renamed Roasting` as suggested.