### PR TITLE
Remove zsh color for comments

### DIFF
--- a/sources/assets/zsh/zshrc
+++ b/sources/assets/zsh/zshrc
@@ -64,7 +64,7 @@ source $HOME/.cargo/env
 
 # Color correction for zsh-syntax-highlighting
 ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=#626262'
-ZSH_HIGHLIGHT_STYLES[comment]='fg=cyan'
+ZSH_HIGHLIGHT_STYLES[comment]='fg=#888888'
 
 # In case pipx ensurepath didn't work, and positionning pipx in priority
 export PATH="/root/.local/bin:$PATH"

--- a/sources/assets/zsh/zshrc
+++ b/sources/assets/zsh/zshrc
@@ -64,6 +64,7 @@ source $HOME/.cargo/env
 
 # Color correction for zsh-syntax-highlighting
 ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=#626262'
+ZSH_HIGHLIGHT_STYLES[comment]='none'
 
 # In case pipx ensurepath didn't work, and positionning pipx in priority
 export PATH="/root/.local/bin:$PATH"

--- a/sources/assets/zsh/zshrc
+++ b/sources/assets/zsh/zshrc
@@ -64,7 +64,7 @@ source $HOME/.cargo/env
 
 # Color correction for zsh-syntax-highlighting
 ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=#626262'
-ZSH_HIGHLIGHT_STYLES[comment]='none'
+ZSH_HIGHLIGHT_STYLES[comment]='fg=cyan'
 
 # In case pipx ensurepath didn't work, and positionning pipx in priority
 export PATH="/root/.local/bin:$PATH"


### PR DESCRIPTION
# Description

Whenever I am in the middle of a command line and I find out that I am missing a piece, I like commenting the line, to easily come back to it later.
However, the way zsh currently behaves completely hides the command as it is basically black on black.

The image below shows how "This is a comment" is displayed (hint: it's written on the first line):

![Exegol-comment hidden](https://github.com/ThePorgs/Exegol-images/assets/774193/095759ab-99a9-429e-b05b-cd32e95c7416)

This PR makes the same comment appear as follows:

![Exegol-comment hidden-after](https://github.com/ThePorgs/Exegol-images/assets/774193/6186e97c-39b4-40e8-a0e1-bbd30c0f3369)

At least we can read something.

This PR is minor and is a customization I have in my-resources, I thought maybe it can be of interest of others.

PR is based on the branch 3.1.1.
