### PR TITLE
Add Bloodhound Community Edition

### DIFF
--- a/sources/assets/bloodhound-ce/bloodhound-ce
+++ b/sources/assets/bloodhound-ce/bloodhound-ce
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if ! pg_isready -q; then
+    service postgresql start
+fi
+
+/opt/tools/BloodHound/bloodhound -configfile /opt/tools/BloodHound/bloodhound.config.json
+

--- a/sources/assets/bloodhound-ce/bloodhound-ce-reset
+++ b/sources/assets/bloodhound-ce/bloodhound-ce-reset
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+sudo -u postgres psql -c "DROP database bloodhound"
+sudo -u postgres psql -c "CREATE DATABASE bloodhound;"
+
+if pg_isready -q; then
+    service postgresql stop
+fi

--- a/sources/assets/bloodhound-ce/bloodhound-ce-reset
+++ b/sources/assets/bloodhound-ce/bloodhound-ce-reset
@@ -6,3 +6,5 @@ sudo -u postgres psql -c "CREATE DATABASE bloodhound;"
 if pg_isready -q; then
     service postgresql stop
 fi
+
+pkill bloodhound

--- a/sources/assets/bloodhound-ce/bloodhound-ce-stop
+++ b/sources/assets/bloodhound-ce/bloodhound-ce-stop
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if pg_isready -q; then
+    service postgresql stop
+fi
+
+pkill bloodhound

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -244,6 +244,7 @@ function install_gf() {
 function post_install() {
     # Function used to clean up post-install files
     colorecho "Cleaning..."
+    apt update
     updatedb
     rm -rfv /tmp/*
     rm -rfv /var/lib/apt/lists/*


### PR DESCRIPTION
# Description

Added **Bloodhound Community Edition**: https://github.com/SpecterOps/BloodHound

**Commands :**

* `bloodhound-ce` (starts psql database and bloodhound service)
* `bloodhound-ce-stop` (stop the psql database and the bloohound service)
* `bloodhoud-ce-reset` (reset the psql database and stop the service + bloodhound service)

Here are the ports used :

`5432` -> PostgreSQL database
`1030` -> Bloodhound-CE web service
`7474 et 7687` -> neo4j database

On first launch the `admin` password will be indicated in the console :

```bash
{"level":"info","time":"2023-08-30T22:29:03.706604982Z","message":"# Initial Password Set To:    1NG9pUCJwQKuJDf1k1TzH63giy_tGPRQ    #"}
```

<img width="1421" alt="image" src="https://github.com/ThePorgs/Exegol-images/assets/51704860/3e72efda-f463-491f-a804-57525156514d">

<img width="1424" alt="image" src="https://github.com/ThePorgs/Exegol-images/assets/51704860/f701b393-20cc-49f6-a8c9-dc546880df3e">

<img width="1426" alt="image" src="https://github.com/ThePorgs/Exegol-images/assets/51704860/1f9b6494-6894-4812-aa58-d734e2d05313">

