### PR TITLE
Use port 80 to connect to gpg keyservers

### DIFF
--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -121,7 +121,8 @@ function install_firefox() {
 function install_rvm() {
     # CODE-CHECK-WHITELIST=add-aliases,add-history,add-to-list
     colorecho "Installing rvm"
-    gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+    # allow to fetch keys when behind a firewall (https://serverfault.com/questions/168826/how-to-install-gpg-keys-from-behind-a-firewall)
+    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
     curl -sSL https://get.rvm.io | bash -s stable --ruby
     source /usr/local/rvm/scripts/rvm
     rvm autolibs read-fail


### PR DESCRIPTION
# Description

In a firewalled environment I ran into the following error:
```text
[EXEGOL] Adding build pipeline test command: cargo --version
[EXEGOL] Installing rvm
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: keyserver receive failed: Connection timed out
```

Using port 80 makes it possible to build the image behind a firewall.

# Point of attention

Feel free to close this, if you think it is unnecessary.
