### PR TITLE
nmap-parse-output

### DIFF
--- a/sources/assets/zsh/aliases.d/nmap-parse-output
+++ b/sources/assets/zsh/aliases.d/nmap-parse-output
@@ -1,1 +1,0 @@
-alias nmap-parse-output='/opt/tools/nmap-parse-output/nmap-parse-output'

--- a/sources/assets/zsh/aliases.d/nmap-parse-output
+++ b/sources/assets/zsh/aliases.d/nmap-parse-output
@@ -1,0 +1,1 @@
+alias nmap-parse-output='/opt/tools/nmap-parse-output/nmap-parse-output'

--- a/sources/assets/zsh/history.d/nmap-parse-output
+++ b/sources/assets/zsh/history.d/nmap-parse-output
@@ -1,4 +1,3 @@
-# nmap-parse-output | grep -E '^  [a-z]' | sed -E -e 's/\[([^ ]+)\]/$\1/g' -e 's/\$service-name/$service_name/' | xargs -i sh -c "echo 'nmap-parse-output \$nmap_xml {}'"
 nmap-parse-output /path/to/nmap.xml all-hosts 
 nmap-parse-output /path/to/nmap.xml banner $service_name
 nmap-parse-output /path/to/nmap.xml blocked-ports 

--- a/sources/assets/zsh/history.d/nmap-parse-output
+++ b/sources/assets/zsh/history.d/nmap-parse-output
@@ -1,0 +1,36 @@
+# nmap-parse-output | grep -E '^  [a-z]' | sed -E -e 's/\[([^ ]+)\]/$\1/g' -e 's/\$service-name/$service_name/' | xargs -i sh -c "echo 'nmap-parse-output \$nmap_xml {}'"
+nmap-parse-output $nmap_xml all-hosts 
+nmap-parse-output $nmap_xml banner $service_name
+nmap-parse-output $nmap_xml blocked-ports 
+nmap-parse-output $nmap_xml group-by-ports 
+nmap-parse-output $nmap_xml group-by-product 
+nmap-parse-output $nmap_xml group-by-service 
+nmap-parse-output $nmap_xml host-ports-protocol 
+nmap-parse-output $nmap_xml host-ports 
+nmap-parse-output $nmap_xml hosts-to-port $port
+nmap-parse-output $nmap_xml hosts 
+nmap-parse-output $nmap_xml http-info 
+nmap-parse-output $nmap_xml http-ports 
+nmap-parse-output $nmap_xml http-title 
+nmap-parse-output $nmap_xml nmap-cmdline 
+nmap-parse-output $nmap_xml port-info $port
+nmap-parse-output $nmap_xml ports-reachable 
+nmap-parse-output $nmap_xml ports 
+nmap-parse-output $nmap_xml product 
+nmap-parse-output $nmap_xml search-product 
+nmap-parse-output $nmap_xml service-names 
+nmap-parse-output $nmap_xml service $service_name
+nmap-parse-output $nmap_xml show-comments 
+nmap-parse-output $nmap_xml ssl-common-name 
+nmap-parse-output $nmap_xml tls-ports 
+nmap-parse-output $nmap_xml comment-hosts $hosts $comment
+nmap-parse-output $nmap_xml comment-ports $ports $comment
+nmap-parse-output $nmap_xml exclude-ports $ports
+nmap-parse-output $nmap_xml exclude $hosts
+nmap-parse-output $nmap_xml include-ports $ports
+nmap-parse-output $nmap_xml include $hosts
+nmap-parse-output $nmap_xml mark-ports $ports $color
+nmap-parse-output $nmap_xml reachable 
+nmap-parse-output $nmap_xml html-bootstrap 
+nmap-parse-output $nmap_xml html 
+nmap-parse-output $nmap_xml to-json

--- a/sources/assets/zsh/history.d/nmap-parse-output
+++ b/sources/assets/zsh/history.d/nmap-parse-output
@@ -1,36 +1,36 @@
 # nmap-parse-output | grep -E '^  [a-z]' | sed -E -e 's/\[([^ ]+)\]/$\1/g' -e 's/\$service-name/$service_name/' | xargs -i sh -c "echo 'nmap-parse-output \$nmap_xml {}'"
-nmap-parse-output $nmap_xml all-hosts 
-nmap-parse-output $nmap_xml banner $service_name
-nmap-parse-output $nmap_xml blocked-ports 
-nmap-parse-output $nmap_xml group-by-ports 
-nmap-parse-output $nmap_xml group-by-product 
-nmap-parse-output $nmap_xml group-by-service 
-nmap-parse-output $nmap_xml host-ports-protocol 
-nmap-parse-output $nmap_xml host-ports 
-nmap-parse-output $nmap_xml hosts-to-port $port
-nmap-parse-output $nmap_xml hosts 
-nmap-parse-output $nmap_xml http-info 
-nmap-parse-output $nmap_xml http-ports 
-nmap-parse-output $nmap_xml http-title 
-nmap-parse-output $nmap_xml nmap-cmdline 
-nmap-parse-output $nmap_xml port-info $port
-nmap-parse-output $nmap_xml ports-reachable 
-nmap-parse-output $nmap_xml ports 
-nmap-parse-output $nmap_xml product 
-nmap-parse-output $nmap_xml search-product 
-nmap-parse-output $nmap_xml service-names 
-nmap-parse-output $nmap_xml service $service_name
-nmap-parse-output $nmap_xml show-comments 
-nmap-parse-output $nmap_xml ssl-common-name 
-nmap-parse-output $nmap_xml tls-ports 
-nmap-parse-output $nmap_xml comment-hosts $hosts $comment
-nmap-parse-output $nmap_xml comment-ports $ports $comment
-nmap-parse-output $nmap_xml exclude-ports $ports
-nmap-parse-output $nmap_xml exclude $hosts
-nmap-parse-output $nmap_xml include-ports $ports
-nmap-parse-output $nmap_xml include $hosts
-nmap-parse-output $nmap_xml mark-ports $ports $color
-nmap-parse-output $nmap_xml reachable 
-nmap-parse-output $nmap_xml html-bootstrap 
-nmap-parse-output $nmap_xml html 
-nmap-parse-output $nmap_xml to-json
+nmap-parse-output /path/to/nmap.xml all-hosts 
+nmap-parse-output /path/to/nmap.xml banner $service_name
+nmap-parse-output /path/to/nmap.xml blocked-ports 
+nmap-parse-output /path/to/nmap.xml group-by-ports 
+nmap-parse-output /path/to/nmap.xml group-by-product 
+nmap-parse-output /path/to/nmap.xml group-by-service 
+nmap-parse-output /path/to/nmap.xml host-ports-protocol 
+nmap-parse-output /path/to/nmap.xml host-ports 
+nmap-parse-output /path/to/nmap.xml hosts-to-port $port
+nmap-parse-output /path/to/nmap.xml hosts 
+nmap-parse-output /path/to/nmap.xml http-info 
+nmap-parse-output /path/to/nmap.xml http-ports 
+nmap-parse-output /path/to/nmap.xml http-title 
+nmap-parse-output /path/to/nmap.xml nmap-cmdline 
+nmap-parse-output /path/to/nmap.xml port-info $port
+nmap-parse-output /path/to/nmap.xml ports-reachable 
+nmap-parse-output /path/to/nmap.xml ports 
+nmap-parse-output /path/to/nmap.xml product 
+nmap-parse-output /path/to/nmap.xml search-product 
+nmap-parse-output /path/to/nmap.xml service-names 
+nmap-parse-output /path/to/nmap.xml service $service_name
+nmap-parse-output /path/to/nmap.xml show-comments 
+nmap-parse-output /path/to/nmap.xml ssl-common-name 
+nmap-parse-output /path/to/nmap.xml tls-ports 
+nmap-parse-output /path/to/nmap.xml comment-hosts $hosts $comment
+nmap-parse-output /path/to/nmap.xml comment-ports $ports $comment
+nmap-parse-output /path/to/nmap.xml exclude-ports $ports
+nmap-parse-output /path/to/nmap.xml exclude $hosts
+nmap-parse-output /path/to/nmap.xml include-ports $ports
+nmap-parse-output /path/to/nmap.xml include $hosts
+nmap-parse-output /path/to/nmap.xml mark-ports $ports $color
+nmap-parse-output /path/to/nmap.xml reachable 
+nmap-parse-output /path/to/nmap.xml html-bootstrap 
+nmap-parse-output /path/to/nmap.xml html 
+nmap-parse-output /path/to/nmap.xml to-json

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -253,6 +253,7 @@ function package_network() {
     install_network_apt_tools
     install_proxychains             # Network tool
     install_nmap                    # Port scanner
+    install_nmap-parse-output       # Parse nmap XML files
     install_autorecon               # External recon tool
     install_dnschef                 # Python DNS server
     install_divideandscan           # Python project to automate port scanning routine

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -100,7 +100,7 @@ function install_nmap-parse-output() {
     ln -s /opt/tools/nmap-parse-output/nmap-parse-output /opt/tools/bin/nmap-parse-output
     add-history nmap-parse-output
     # nmap-parse-output always exits with 1 if no argument is passed
-    add-test-command "nmap-parse-output | grep -E '^\[v.+\]'"
+    add-test-command "nmap-parse-output |& grep -E '^\[v.+\]'"
     add-to-list "nmap-parse-ouptut,https://github.com/ernw/nmap-parse-output,Converts/manipulates/extracts data from a Nmap scan output."
 }
 

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -93,10 +93,11 @@ function install_nmap() {
 }
 
 function install_nmap-parse-output() {
+    # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing nmap-parse-output"
     fapt xsltproc
     git -C /opt/tools/ clone --depth 1 https://github.com/ernw/nmap-parse-output
-    add-aliases nmap-parse-output
+    ln -s /opt/tools/nmap-parse-output/nmap-parse-output /opt/tools/bin/nmap-parse-output
     add-history nmap-parse-output
     # nmap-parse-output always exits with 1 if no argument is passed
     add-test-command "nmap-parse-output | grep -E '^\[v.+\]'"

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -92,6 +92,17 @@ function install_nmap() {
     add-to-list "nmap,https://nmap.org,The Network Mapper - a powerful network discovery and security auditing tool"
 }
 
+function install_nmap-parse-output() {
+    colorecho "Installing nmap-parse-output"
+    fapt xsltproc
+    git -C /opt/tools/ clone --depth 1 https://github.com/ernw/nmap-parse-output
+    add-aliases nmap-parse-output
+    add-history nmap-parse-output
+    # nmap-parse-output always exits with 1 if no argument is passed
+    add-test-command "nmap-parse-output | grep -E '^\[v.+\]'"
+    add-to-list "nmap-parse-ouptut,https://github.com/ernw/nmap-parse-output,Converts/manipulates/extracts data from a Nmap scan output."
+}
+
 function install_autorecon() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing autorecon"


### PR DESCRIPTION
# Description

New tool nmap-parse-output to parse XML output of nmap (`nmap -oX file.xml`).

# Point of attention

- Not sure if the test command works as expected. Otherwise `which nmap-parse-output` could also be used. `grep` is used to look for the version number and it fails if it's not in the output.
- The tool also provides shell completions (https://github.com/ernw/nmap-parse-output?tab=readme-ov-file#zsh-completion). I am not sure how this can and should be added to the image.
