### PR TITLE
Refacto pip installs CNR

### DIFF
--- a/.github/workflows/entrypoint_pr.yml
+++ b/.github/workflows/entrypoint_pr.yml
@@ -84,7 +84,7 @@ jobs:
 
   build:
     name: Final image build
-    needs: [init, code_check, build_base ]
+    needs: [ init, code_check, build_base ]
     # only running build if base_build was a success
     if: needs.build_base.outputs.build == 'success'
     strategy:

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -42,9 +42,11 @@ function install_responder() {
       for PR in "${PRS[@]}"; do git fetch origin "pull/$PR/head:pull/$PR" && git merge --strategy-option theirs --no-edit "pull/$PR"; done
     fi
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
     # following requirements needed by MultiRelay.py
-    catch_and_retry ./venv/bin/python3 -m pip install pycryptodome pycryptodomex six
+    pip3 install pycryptodome pycryptodomex six
+    deactivate
     sed -i 's/ Random/ 1122334455667788/g' /opt/tools/Responder/Responder.conf
     sed -i 's/files\/AccessDenied.html/\/opt\/tools\/Responder\/files\/AccessDenied.html/g' /opt/tools/Responder/Responder.conf
     sed -i 's/files\/BindShell.exe/\/opt\/tools\/Responder\/files\/BindShell.exe/g' /opt/tools/Responder/Responder.conf
@@ -213,7 +215,9 @@ function install_privexchange() {
     git -C /opt/tools/ clone --depth 1 https://github.com/dirkjanm/PrivExchange
     cd /opt/tools/PrivExchange || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install impacket
+    source ./venv/bin/activate
+    pip3 install impacket
+    deactivate
     add-aliases privexchange
     add-history privexchange
     add-test-command "privexchange.py --help"
@@ -314,7 +318,9 @@ function install_krbrelayx() {
     git -C /opt/tools/ clone --depth 1 https://github.com/dirkjanm/krbrelayx
     cd /opt/tools/krbrelayx || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install dnspython ldap3 impacket dsinternals
+    source ./venv/bin/activate
+    pip3 install dnspython ldap3 impacket dsinternals
+    deactivate
     cp -v /root/sources/assets/grc/conf.krbrelayx /usr/share/grc/conf.krbrelayx
     add-aliases krbrelayx
     add-history krbrelayx
@@ -376,7 +382,9 @@ function install_zerologon() {
     mkdir /opt/tools/zerologon
     cd /opt/tools/zerologon || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install impacket
+    source ./venv/bin/activate
+    pip3 install impacket
+    deactivate
     git -C /opt/tools/zerologon clone --depth 1 https://github.com/SecuraBV/CVE-2020-1472 zerologon-scan
     git -C /opt/tools/zerologon clone --depth 1 https://github.com/dirkjanm/CVE-2020-1472 zerologon-exploit
     add-aliases zerologon
@@ -420,7 +428,9 @@ function install_oaburl() {
     wget -O /opt/tools/OABUrl/oaburl.py "https://gist.githubusercontent.com/snovvcrash/4e76aaf2a8750922f546eed81aa51438/raw/96ec2f68a905eed4d519d9734e62edba96fd15ff/oaburl.py"
     cd /opt/tools/OABUrl/ || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install requests
+    source ./venv/bin/activate
+    pip3 install requests
+    deactivate
     add-aliases oaburl
     add-history oaburl
     add-test-command "oaburl.py --help"
@@ -432,7 +442,9 @@ function install_lnkup() {
     git -C /opt/tools/ clone --depth 1 https://github.com/Plazmaz/LNKUp
     cd /opt/tools/LNKUp || exit
     virtualenv --python python2 ./venv
-    catch_and_retry ./venv/bin/python2 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip2 install -r requirements.txt
+    deactivate
     add-aliases lnkup
     add-history lnkup
     add-test-command "lnk-generate.py --help"
@@ -444,7 +456,9 @@ function install_polenum() {
     git -C /opt/tools/ clone --depth 1 https://github.com/Wh1t3Fox/polenum
     cd /opt/tools/polenum || exit
     python3 -m venv ./venv/
-    catch_and_retry ./venv/bin/python3 -m pip install impacket
+    source ./venv/bin/activate
+    pip3 install impacket
+    deactivate
     add-aliases polenum
     add-history polenum
     add-test-command "polenum.py --help"
@@ -499,7 +513,9 @@ function install_gpp-decrypt() {
     git -C /opt/tools/ clone --depth 1 https://github.com/t0thkr1s/gpp-decrypt
     cd /opt/tools/gpp-decrypt || exit
     python3 -m venv ./venv/
-    catch_and_retry ./venv/bin/python3 -m pip install pycryptodome colorama
+    source ./venv/bin/activate
+    pip3 install pycryptodome colorama
+    deactivate
     add-aliases gpp-decrypt
     add-history gpp-decrypt
     add-test-command "gpp-decrypt.py -f /opt/tools/gpp-decrypt/groups.xml"
@@ -547,7 +563,9 @@ function install_pygpoabuse() {
     git -C /opt/tools/ clone --depth 1 https://github.com/Hackndo/pyGPOAbuse
     cd /opt/tools/pyGPOAbuse || exit
     python3 -m venv ./venv/
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases pygpoabuse
     add-history pygpoabuse
     add-test-command "pygpoabuse.py --help"
@@ -568,7 +586,9 @@ function install_bloodhound-quickwin() {
     git -C /opt/tools/ clone --depth 1 https://github.com/kaluche/bloodhound-quickwin
     cd /opt/tools/bloodhound-quickwin || exit
     python3 -m venv ./venv/
-    catch_and_retry ./venv/bin/python3 -m pip install py2neo pandas prettytable
+    source ./venv/bin/activate
+    pip3 install py2neo pandas prettytable
+    deactivate
     add-aliases bloodhound-quickwin
     add-history bloodhound-quickwin
     add-test-command "bloodhound-quickwin --help"
@@ -580,7 +600,9 @@ function install_ldapsearch-ad() {
     git -C /opt/tools/ clone --depth 1 https://github.com/yaap7/ldapsearch-ad
     cd /opt/tools/ldapsearch-ad || exit
     python3 -m venv ./venv/
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases ldapsearch-ad
     add-history ldapsearch-ad
     add-test-command "ldapsearch-ad.py --version"
@@ -592,12 +614,16 @@ function install_petitpotam() {
     git -C /opt/tools/ clone --depth 1 https://github.com/ly4k/PetitPotam
     cd /opt/tools/PetitPotam || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install impacket
+    source ./venv/bin/activate
+    pip3 install impacket
+    deactivate
     mv /opt/tools/PetitPotam /opt/tools/PetitPotam_alt
     git -C /opt/tools/ clone --depth 1 https://github.com/topotam/PetitPotam
     cd /opt/tools/PetitPotam || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install impacket
+    source ./venv/bin/activate
+    pip3 install impacket
+    deactivate
     add-aliases petitpotam
     add-history petitpotam
     add-test-command "petitpotam.py --help"
@@ -609,7 +635,9 @@ function install_dfscoerce() {
     git -C /opt/tools/ clone --depth 1 https://github.com/Wh04m1001/DFSCoerce
     cd /opt/tools/DFSCoerce || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install impacket
+    source ./venv/bin/activate
+    pip3 install impacket
+    deactivate
     add-aliases dfscoerce
     add-history dfscoerce
     add-test-command "dfscoerce.py --help"
@@ -630,7 +658,9 @@ function install_pkinittools() {
     git -C /opt/tools/ clone --depth 1 https://github.com/dirkjanm/PKINITtools
     cd /opt/tools/PKINITtools || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases pkinittools
     add-history pkinittools
     add-test-command "gettgtpkinit.py --help"
@@ -642,7 +672,9 @@ function install_pywhisker() {
     git -C /opt/tools/ clone --depth 1 https://github.com/ShutdownRepo/pywhisker
     cd /opt/tools/pywhisker || exit
     python3 -m venv ./venv/
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases pywhisker
     add-history pywhisker
     add-test-command "pywhisker.py --help"
@@ -654,7 +686,9 @@ function install_manspider() {
     git -C /opt/tools clone --depth 1 https://github.com/blacklanternsecurity/MANSPIDER.git
     cd /opt/tools/MANSPIDER || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install .
+    source ./venv/bin/activate
+    pip3 install .
+    deactivate
     touch ./man_spider/lib/init.py
     sed -i "s#from .lib import#from lib import##" man_spider/manspider.py
     add-aliases manspider
@@ -668,7 +702,9 @@ function install_targetedKerberoast() {
     git -C /opt/tools/ clone --depth 1 https://github.com/ShutdownRepo/targetedKerberoast
     cd /opt/tools/targetedKerberoast || exit
     python3 -m venv ./venv/
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases targetedkerberoast
     add-history targetedkerberoast
     add-test-command "targetedKerberoast.py --help"
@@ -681,8 +717,9 @@ function install_pcredz() {
     git -C /opt/tools/ clone --depth 1 https://github.com/lgandx/PCredz
     cd /opt/tools/PCredz || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install Cython
-    catch_and_retry ./venv/bin/python3 -m pip install python-libpcap
+    source ./venv/bin/activate
+    pip3 install Cython python-libpcap
+    deactivate
     add-aliases pcredz
     add-history pcredz
     add-test-command "PCredz --help"
@@ -696,7 +733,9 @@ function install_pywsus() {
     python3 -m venv ./venv/
     # https://github.com/GoSecure/pywsus/pull/12
     echo -e "beautifulsoup4==4.9.1\nlxml==4.9.1\nsoupsieve==2.0.1" > requirements.txt
-    catch_and_retry ./venv/bin/python3 -m pip install -r ./requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases pywsus
     add-history pywsus
     add-test-command "pywsus.py --help"
@@ -736,7 +775,9 @@ function install_shadowcoerce() {
     git -C /opt/tools/ clone --depth 1 https://github.com/ShutdownRepo/ShadowCoerce
     cd /opt/tools/ShadowCoerce || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install impacket
+    source ./venv/bin/activate
+    pip3 install impacket
+    deactivate
     add-aliases shadowcoerce
     add-history shadowcoerce
     add-test-command "shadowcoerce.py --help"
@@ -748,7 +789,9 @@ function install_gmsadumper() {
     git -C /opt/tools/ clone --depth 1 https://github.com/micahvandeusen/gMSADumper
     cd /opt/tools/gMSADumper || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases gmsadumper
     add-history gmsadumper
     add-test-command "gMSADumper.py --help"
@@ -760,7 +803,9 @@ function install_pylaps() {
     git -C /opt/tools/ clone --depth 1 https://github.com/p0dalirius/pyLAPS
     cd /opt/tools/pyLAPS || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install impacket
+    source ./venv/bin/activate
+    pip3 install impacket
+    deactivate
     add-aliases pylaps
     add-history pylaps
     add-test-command "pyLAPS.py --help"
@@ -772,7 +817,9 @@ function install_finduncommonshares() {
     git -C /opt/tools/ clone --depth 1 https://github.com/p0dalirius/FindUncommonShares
     cd /opt/tools/FindUncommonShares/ || exit
     python3 -m venv ./venv/
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases finduncommonshares
     add-history finduncommonshares
     add-test-command "FindUncommonShares.py --help"
@@ -784,7 +831,9 @@ function install_ldaprelayscan() {
     git -C /opt/tools/ clone --depth 1 https://github.com/zyn3rgy/LdapRelayScan
     cd /opt/tools/LdapRelayScan || exit
     python3 -m venv ./venv/
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases ldaprelayscan
     add-history ldaprelayscan
     add-test-command "LdapRelayScan.py --help"
@@ -814,7 +863,9 @@ function install_crackhound() {
       for PR in "${PRS[@]}"; do git fetch origin "pull/$PR/head:pull/$PR" && git merge --strategy-option theirs --no-edit "pull/$PR"; done
     fi
     python3 -m venv ./venv/
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases crackhound
     add-history crackhound
     add-test-command "crackhound.py --help"
@@ -915,7 +966,9 @@ function install_PassTheCert() {
     git -C /opt/tools/ clone --depth 1 https://github.com/AlmondOffSec/PassTheCert
     cd /opt/tools/PassTheCert/Python/ || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install impacket
+    source ./venv/bin/activate
+    pip3 install impacket
+    deactivate
     add-aliases PassTheCert
     add-history PassTheCert
     add-test-command "passthecert.py --help"
@@ -960,7 +1013,9 @@ function install_noPac() {
     git -C /opt/tools/ clone --depth 1 https://github.com/Ridter/noPac
     cd /opt/tools/noPac || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases noPac
     add-history noPac
     add-test-command "noPac.py --help"
@@ -981,7 +1036,9 @@ function install_teamsphisher() {
     git -C /opt/tools clone --depth 1 https://github.com/Octoberfest7/TeamsPhisher
     cd /opt/tools/TeamsPhisher || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install msal colorama requests
+    source ./venv/bin/activate
+    pip3 install msal colorama requests
+    deactivate
     add-aliases teamsphisher
     add-history teamsphisher
     add-test-command "teamsphisher.py --help"
@@ -1016,7 +1073,9 @@ function install_extractbitlockerkeys() {
     git -C /opt/tools/ clone --depth 1 https://github.com/p0dalirius/ExtractBitlockerKeys
     cd /opt/tools/ExtractBitlockerKeys || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases extractbitlockerkeys
     add-history extractbitlockerkeys
     add-test-command "extractbitlockerkeys.py|& grep 'usage: ExtractBitlockerKeys.py'"

--- a/sources/install/package_cloud.sh
+++ b/sources/install/package_cloud.sh
@@ -95,8 +95,8 @@ function install_cloudmapper() {
     git apply --verbose cloudmapper.patch
     python3 -m venv ./venv
     source ./venv/bin/activate
-    pip3 install -r requirements.txt
     pip3 install wheel
+    pip3 install -r requirements.txt
     deactivate
     add-aliases cloudmapper
     add-history cloudmapper

--- a/sources/install/package_cloud.sh
+++ b/sources/install/package_cloud.sh
@@ -90,12 +90,14 @@ function install_prowler() {
 function install_cloudmapper() {
     colorecho "Installing Cloudmapper"
     git -C /opt/tools clone --depth 1 https://github.com/duo-labs/cloudmapper.git 
-    cd /opt/tools/cloudmapper
+    cd /opt/tools/cloudmapper || exit
     cp -v /root/sources/assets/patches/cloudmapper.patch cloudmapper.patch
     git apply --verbose cloudmapper.patch
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install wheel
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    pip3 install wheel
+    deactivate
     add-aliases cloudmapper
     add-history cloudmapper
     add-test-command 'cloudmapper.py --help |& grep "usage"'

--- a/sources/install/package_crypto.sh
+++ b/sources/install/package_crypto.sh
@@ -19,9 +19,11 @@ function install_rsactftool() {
     # This tool uses z3solver, which is very long to build (5 min)
     fapt libmpc-dev
     git -C /opt/tools clone --depth 1 https://github.com/RsaCtfTool/RsaCtfTool
-    cd /opt/tools/RsaCtfTool
+    cd /opt/tools/RsaCtfTool || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases rsactftool
     add-history rsactftool
     add-test-command "RsaCtfTool.py --help"

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -34,9 +34,9 @@ function install_volatility2() {
     git -C /opt/tools/ clone --depth 1 https://github.com/volatilityfoundation/volatility
     cd /opt/tools/volatility
     virtualenv --python python2 ./venv
-    catch_and_retry ./venv/bin/python2 -m pip install pycryptodome distorm3 pillow openpyxl
-    catch_and_retry ./venv/bin/python2 -m pip install ujson --no-use-pep517
     source ./venv/bin/activate
+    pip2 install pycryptodome distorm3 pillow openpyxl
+    pip2 install ujson --no-use-pep517
     python2 setup.py install
     deactivate
     # https://github.com/volatilityfoundation/volatility/issues/535#issuecomment-407571161

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -125,7 +125,9 @@ function install_dnschef() {
     git -C /opt/tools/ clone --depth 1 https://github.com/iphelix/dnschef
     cd /opt/tools/dnschef || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases dnschef
     add-history dnschef
     add-test-command "dnschef.py --help"
@@ -166,7 +168,9 @@ function install_eaphammer() {
     cd /opt/tools/eaphammer || exit
     xargs apt install -y < kali-dependencies.txt
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r pip.req
+    source ./venv/bin/activate
+    pip3 install -r pip.req
+    deactivate
     add-aliases eaphammer
     add-history eaphammer
     add-test-command "eaphammer -h"

--- a/sources/install/package_osint.sh
+++ b/sources/install/package_osint.sh
@@ -105,7 +105,9 @@ function install_simplyemail() {
     cd /opt/tools/SimplyEmail/ || exit
     fapt antiword odt2txt libxml2-dev libxslt1-dev
     virtualenv --python python2 ./venv
-    catch_and_retry ./venv/bin/python2 -m pip install -r ./setup/requirments.txt
+    source ./venv/bin/activate
+    pip2 install -r ./setup/requirments.txt
+    deactivate
     add-aliases simplyemail
     add-history simplyemail
     add-test-command "SimplyEmail.py -l"
@@ -117,7 +119,9 @@ function install_theharvester() {
     git -C /opt/tools/ clone --depth 1 https://github.com/laramies/theHarvester
     cd /opt/tools/theHarvester || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     # The tool needs access to the proxies.yaml file in the folder.
     ln -s /opt/tools/theHarvester /usr/local/etc/
     add-aliases theharvester
@@ -141,7 +145,9 @@ function install_infoga() {
     find /opt/tools/Infoga/ -type f -print0 | xargs -0 dos2unix
     cd /opt/tools/Infoga || exit
     python2 -m virtualenv ./venv
-    catch_and_retry ./venv/bin/python2 -m pip install .
+    source ./venv/bin/activate
+    pip2 install .
+    deactivate
     add-aliases infoga
     add-history infoga
     add-test-command "infoga.py --help"
@@ -170,7 +176,9 @@ function install_pwnedornot() {
     git -C /opt/tools/ clone --depth 1 https://github.com/thewhiteh4t/pwnedOrNot
     cd /opt/tools/pwnedOrNot || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install requests html2text
+    source ./venv/bin/activate
+    pip3 install requests html2text
+    deactivate
     mkdir -p "$HOME/.config/pwnedornot"
     cp config.json "$HOME/.config/pwnedornot/config.json"
     add-aliases pwnedornot
@@ -212,7 +220,9 @@ function install_linkedin2username() {
     git -C /opt/tools/ clone --depth 1 https://github.com/initstring/linkedin2username
     cd /opt/tools/linkedin2username || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases linkedin2username
     add-history linkedin2username
     add-test-command "linkedin2username.py --help"
@@ -242,7 +252,9 @@ function install_carbon14() {
     git -C /opt/tools/ clone --depth 1 https://github.com/Lazza/Carbon14
     cd /opt/tools/Carbon14 || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases carbon14
     add-history carbon14
     add-test-command "carbon14.py --help"
@@ -254,7 +266,9 @@ function install_photon() {
     git -C /opt/tools/ clone --depth 1 https://github.com/s0md3v/photon
     cd /opt/tools/photon || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases photon
     add-history photon
     add-test-command "photon.py --help"
@@ -304,7 +318,9 @@ function install_spiderfoot() {
     git -C /opt/tools/ clone --depth 1 https://github.com/smicallef/spiderfoot
     cd /opt/tools/spiderfoot || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases spiderfoot
     add-history spiderfoot
     add-test-command "spiderfoot --help"
@@ -317,7 +333,9 @@ function install_finalrecon() {
     git -C /opt/tools/ clone --depth 1 https://github.com/thewhiteh4t/FinalRecon
     cd /opt/tools/FinalRecon || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases finalrecon
     add-history finalrecon
     add-test-command "finalrecon.py --help"
@@ -340,7 +358,9 @@ function install_pwndb() {
     git -C /opt/tools/ clone --depth 1 https://github.com/davidtavarez/pwndb.git
     cd /opt/tools/pwndb || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases pwndb
     add-history pwndb
     add-test-command "pwndb.py --help"
@@ -362,7 +382,9 @@ function install_recondog() {
     git -C /opt/tools/ clone --depth 1 https://github.com/s0md3v/ReconDog
     cd /opt/tools/ReconDog/ || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases recondog
     add-history recondog
     add-test-command "recondog --help"
@@ -415,7 +437,9 @@ function install_geopincer() {
     cd /opt/tools/GeoPincer || exit
     sed -i "s#regions.txt#/opt/tools/GeoPincer/regions.txt##" GeoPincer.py
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases geopincer
     add-history geopincer
     add-test-command "geopincer.py --help"
@@ -439,7 +463,9 @@ function install_murmurhash() {
     git -C /opt/tools clone --depth 1 https://github.com/QU35T-code/MurMurHash
     cd /opt/tools/MurMurHash || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases MurMurHash
     add-history MurMurHash
     add-test-command "MurMurHash.py"
@@ -453,7 +479,9 @@ function install_blackbird() {
     sed -i "s#data.json#/opt/tools/blackbird/data.json#" blackbird.py
     sed -i "s#useragents.txt#/opt/tools/blackbird/useragents.txt#" blackbird.py
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases blackbird
     add-history blackbird
     add-test-command "blackbird.py --help"
@@ -465,7 +493,9 @@ function install_sherlock() {
     git -C /opt/tools/ clone --depth 1 https://github.com/sherlock-project/sherlock
     cd /opt/tools/sherlock || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases sherlock
     add-history sherlock
     add-test-command "sherlock.py --help"

--- a/sources/install/package_reverse.sh
+++ b/sources/install/package_reverse.sh
@@ -67,8 +67,10 @@ function install_checksec-py() {
     git -C /opt/tools/ clone --depth 1 https://github.com/Wenzel/checksec.py.git
     cd /opt/tools/checksec.py
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install .
-    catch_and_retry ./venv/bin/python3 -m pip install --upgrade lief
+    source ./venv/bin/activate
+    pip3 install .
+    pip3 install --upgrade lief
+    deactivate
     add-aliases checksec
     add-history checksec
     add-test-command "checksec.py --help"

--- a/sources/install/package_rfid.sh
+++ b/sources/install/package_rfid.sh
@@ -62,7 +62,9 @@ function install_mfdread() {
     git -C /opt/tools/ clone --depth 1 https://github.com/zhovner/mfdread
     cd /opt/tools/mfdread || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install bitstring
+    source ./venv/bin/activate
+    pip3 install bitstring
+    deactivate
     add-aliases mfdread
     add-history mfdread
     add-test-command "mfdread.py /opt/tools/mfdread/dump.mfd"

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -29,7 +29,9 @@ function install_weevely() {
     git -C /opt/tools clone --depth 1 https://github.com/epinna/weevely3
     cd /opt/tools/weevely3 || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases weevely
     add-history weevely
     add-test-command "weevely.py --help"
@@ -126,7 +128,9 @@ function install_ssrfmap() {
     git -C /opt/tools/ clone --depth 1 https://github.com/swisskyrepo/SSRFmap
     cd /opt/tools/SSRFmap || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases ssrfmap
     add-history ssrfmap
     add-test-command "ssrfmap.py --help"
@@ -138,7 +142,9 @@ function install_gopherus() {
     git -C /opt/tools/ clone --depth 1 https://github.com/tarunkant/Gopherus
     cd /opt/tools/Gopherus || exit
     virtualenv --python python2 ./venv
-    catch_and_retry ./venv/bin/python2 -m pip install argparse requests
+    source ./venv/bin/activate
+    pip2 install argparse requests
+    deactivate
     add-aliases gopherus
     add-history gopherus
     add-test-command "gopherus.py --help"
@@ -153,7 +159,9 @@ function install_nosqlmap() {
     catch_and_retry ./venv/bin/python2 setup.py install
     # https://github.com/codingo/NoSQLMap/issues/126
     rm -rf venv/lib/python2.7/site-packages/certifi-2023.5.7-py2.7.egg
-    catch_and_retry ./venv/bin/python2 -m pip install certifi==2018.10.15
+    source ./venv/bin/activate
+    pip2 install certifi==2018.10.15
+    deactivate
     add-aliases nosqlmap
     add-history nosqlmap
     add-test-command "nosqlmap.py --help"
@@ -165,7 +173,9 @@ function install_xsstrike() {
     git -C /opt/tools/ clone --depth 1 https://github.com/s0md3v/XSStrike.git
     cd /opt/tools/XSStrike || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases xsstrike
     add-history xsstrike
     add-test-command "xsstrike.py --help"
@@ -188,7 +198,9 @@ function install_xsser() {
     git -C /opt/tools clone --depth 1 https://github.com/epsylon/xsser.git
     cd /opt/tools/xsser || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install pycurl bs4 pygeoip gobject cairocffi selenium
+    source ./venv/bin/activate
+    pip3 install pycurl bs4 pygeoip gobject cairocffi selenium
+    deactivate
     add-aliases xsser
     add-history xsser
     add-test-command "xsser --help"
@@ -209,7 +221,9 @@ function install_bolt() {
     git -C /opt/tools/ clone --depth 1 https://github.com/s0md3v/Bolt.git
     cd /opt/tools/Bolt || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases bolt
     add-history bolt
     add-test-command "bolt.py --help"
@@ -234,7 +248,9 @@ function install_fuxploider() {
     git -C /opt/tools/ clone --depth 1 https://github.com/almandin/fuxploider.git
     cd /opt/tools/fuxploider || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases fuxploider
     add-history fuxploider
     add-test-command "fuxploider.py --help"
@@ -247,7 +263,9 @@ function install_patator() {
     git -C /opt/tools clone --depth 1 https://github.com/lanjelot/patator.git
     cd /opt/tools/patator || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases patator
     add-history patator
     add-test-command "patator.py ftp_login --help"
@@ -310,8 +328,11 @@ function install_moodlescan() {
     git -C /opt/tools/ clone --depth 1 https://github.com/inc0d3/moodlescan.git
     cd /opt/tools/moodlescan || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     cd /opt/tools/moodlescan || exit
+    # updating moodlescan database
     catch_and_retry ./venv/bin/python3 moodlescan.py -a
     add-aliases moodlescan
     add-history moodlescan
@@ -348,7 +369,9 @@ function install_cloudfail() {
     git -C /opt/tools/ clone --depth 1 https://github.com/m0rtem/CloudFail
     cd /opt/tools/CloudFail || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases cloudfail
     add-history cloudfail
     add-test-command "cloudfail.py --help"
@@ -383,7 +406,9 @@ function install_oneforall() {
       for PR in "${PRS[@]}"; do git fetch origin "pull/$PR/head:pull/$PR" && git merge --strategy-option theirs --no-edit "pull/$PR"; done
     fi
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases oneforall
     add-history oneforall
     add-test-command "oneforall.py version"
@@ -404,7 +429,9 @@ function install_corscanner() {
     git -C /opt/tools/ clone --depth 1 https://github.com/chenjj/CORScanner.git
     cd /opt/tools/CORScanner || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases corscanner
     add-history corscanner
     add-test-command "cors_scan.py --help"
@@ -435,7 +462,9 @@ function install_linkfinder() {
     git -C /opt/tools/ clone --depth 1 https://github.com/GerbenJavado/LinkFinder.git
     cd /opt/tools/LinkFinder || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases linkfinder
     add-history linkfinder
     add-test-command "linkfinder.py --help"
@@ -467,7 +496,9 @@ function install_jwt_tool() {
     git -C /opt/tools/ clone --depth 1 https://github.com/ticarpi/jwt_tool
     cd /opt/tools/jwt_tool || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases jwt_tool
     add-history jwt_tool
     add-test-command "jwt_tool.py --help"
@@ -497,7 +528,9 @@ function install_gittools() {
     git -C /opt/tools/ clone --depth 1 https://github.com/internetwache/GitTools.git
     cd /opt/tools/GitTools/Finder || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases gittools
     add-history gittools
     add-test-command "extractor.sh --help|& grep 'USAGE: extractor.sh GIT-DIR DEST-DIR'"
@@ -549,7 +582,9 @@ function install_httpmethods() {
     git -C /opt/tools/ clone --depth 1 https://github.com/ShutdownRepo/httpmethods
     cd /opt/tools/httpmethods || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases httpmethods
     add-history httpmethods
     add-test-command "httpmethods.py --help"
@@ -561,7 +596,9 @@ function install_h2csmuggler() {
     git -C /opt/tools/ clone --depth 1 https://github.com/BishopFox/h2csmuggler
     cd /opt/tools/h2csmuggler || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install h2
+    source ./venv/bin/activate
+    pip3 install h2
+    deactivate
     add-aliases h2csmuggler
     add-history h2csmuggler
     add-test-command "h2csmuggler.py --help"
@@ -597,7 +634,9 @@ function install_tomcatwardeployer() {
     git -C /opt/tools/ clone --depth 1 https://github.com/mgeeky/tomcatWarDeployer.git
     cd /opt/tools/tomcatWarDeployer || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases tomcatwardeployer
     add-history tomcatwardeployer
     add-test-command "tomcatWarDeployer.py --help"
@@ -609,7 +648,9 @@ function install_clusterd() {
     git -C /opt/tools/ clone --depth 1 https://github.com/hatRiot/clusterd.git
     cd /opt/tools/clusterd || exit
     virtualenv --python python2 ./venv
-    catch_and_retry ./venv/bin/python2 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip2 install -r requirements.txt
+    deactivate
     add-aliases clusterd
     add-history clusterd
     add-test-command "clusterd.py --help"
@@ -742,7 +783,9 @@ function install_kraken() {
     git -C /opt/tools clone --depth 1 --recurse-submodules https://github.com/kraken-ng/Kraken.git
     cd /opt/tools/Kraken || exit
     python3 -m venv ./venv
-    catch_and_retry ./venv/bin/python3 -m pip install -r requirements.txt
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases kraken
     add-history kraken
     add-test-command "kraken.py -h"

--- a/sources/install/package_wifi.sh
+++ b/sources/install/package_wifi.sh
@@ -31,7 +31,9 @@ function install_pyrit() {
     cd /opt/tools/Pyrit
     fapt libpq-dev
     virtualenv --python python2 ./venv
-    catch_and_retry ./venv/bin/python2 -m pip install psycopg2-binary scapy
+    source ./venv/bin/activate
+    pip2 install psycopg2-binary scapy
+    deactivate
     # https://github.com/JPaulMora/Pyrit/issues/591
     cp -v /root/sources/assets/patches/undefined-symbol-aesni-key.patch undefined-symbol-aesni-key.patch
     git apply --verbose undefined-symbol-aesni-key.patch


### PR DESCRIPTION
When installing deps through a venv, the `./venv/bin/python3` is not transparently made through CNR (Catch And Retry). Requires to prepend the command line with the CNR like: `catch_and_retry ./venv/bin/python -m pip install deps ...`

Would be better to do this:
```bash
cd /path/to/tool || exit
source ./venv/bin/activate
pip3 install -r ./requirements.txt
deactivate
```

`pip2/pip3` are transparently handled through CNR.