### PR TITLE
load_supported_setups: fix bqm not found, and BloodHound customqueries

### DIFF
--- a/sources/assets/exegol/load_supported_setups.sh
+++ b/sources/assets/exegol/load_supported_setups.sh
@@ -31,7 +31,6 @@ function criticalecho-noexit () {
 
 function init() {
   colorecho "Initialization"
-  colorecho "Sourcing zshrc"
   colorecho "Checking environment variables"
   env
   colorecho "Deploying /opt/my-resources"


### PR DESCRIPTION
1/ BloodHound customqueries for `my-resources` was broken again after moving the `source` command into a function. The end result was that the `bqm` executable could not be found.

2/ In the process, I found and fixed another regression (which I introduced) when BloodHound customqueries files are both in the directories `merge` and `replacement`.

Fix tested with success.