### PR TITLE
Adding cewler

### DIFF
--- a/sources/assets/zsh/history.d/cewler
+++ b/sources/assets/zsh/history.d/cewler
@@ -1,0 +1,2 @@
+cewler --output cewler.txt "$TARGET"
+cewler --output cewler.txt --depth 5 --lowercase --min-word-length 2 --without-numbers "$TARGET"

--- a/sources/install/package_wordlists.sh
+++ b/sources/install/package_wordlists.sh
@@ -36,7 +36,7 @@ function install_cewler() {
     coloercho "Installing cewler"
     pipx install cewler
     add-history cewler
-    add-test-command "cewler --help"
+    add-test-command "cewler --output cewler.txt https://thehacker.recipes/"
     add-to-list "cewler,https://github.com/roys/cewler,CeWL alternative in Python"
 }
 

--- a/sources/install/package_wordlists.sh
+++ b/sources/install/package_wordlists.sh
@@ -31,6 +31,15 @@ function install_cewl() {
     add-to-list "cewl,https://digi.ninja/projects/cewl.php,Generates custom wordlists by spidering a target's website and parsing the results"
 }
 
+function install_cewler() {
+    # CODE-CHECK-WHITELIST=add-aliases
+    coloercho "Installing cewler"
+    pipx install cewler
+    add-history cewler
+    add-test-command "cewler --help"
+    add-to-list "cewler,https://github.com/roys/cewler,CeWL alternative in Python"
+}
+
 function install_seclists() {
     # CODE-CHECK-WHITELIST=add-aliases,add-history
     colorecho "Installing seclists"
@@ -92,6 +101,7 @@ function package_wordlists() {
     set_python_env
     install_wordlists_apt_tools
     install_cewl                    # Wordlist generator
+    install_cewler                  # cewl alternative in Python
     install_seclists                # Awesome wordlists
     install_pass_station            # Default credentials database
     install_username-anarchy        # Generate possible usernames based on heuristics

--- a/sources/install/package_wordlists.sh
+++ b/sources/install/package_wordlists.sh
@@ -33,7 +33,7 @@ function install_cewl() {
 
 function install_cewler() {
     # CODE-CHECK-WHITELIST=add-aliases
-    coloercho "Installing cewler"
+    colorecho "Installing cewler"
     pipx install cewler
     # https://github.com/roys/cewler/issues/1
     local TEMP_FIX_LIMIT="2024-10-01"

--- a/sources/install/package_wordlists.sh
+++ b/sources/install/package_wordlists.sh
@@ -35,6 +35,13 @@ function install_cewler() {
     # CODE-CHECK-WHITELIST=add-aliases
     coloercho "Installing cewler"
     pipx install cewler
+    # https://github.com/roys/cewler/issues/1
+    local TEMP_FIX_LIMIT="2024-10-01"
+    if [ "$(date +%Y%m%d)" -gt "$(date -d $TEMP_FIX_LIMIT +%Y%m%d)" ]; then
+      criticalecho "Temp fix expired. Exiting."
+    else
+      pipx inject cewler Twisted==22.10.0
+    fi
     add-history cewler
     add-test-command "cewler --output cewler.txt https://thehacker.recipes/"
     add-to-list "cewler,https://github.com/roys/cewler,CeWL alternative in Python"


### PR DESCRIPTION
Adding [cewler](https://github.com/roys/cewler), a Python alternative to [cewl](https://github.com/digininja/CeWL)
Putting the PR on hold for now, as the tool raises an issue when used (https://github.com/roys/cewler/issues/1)