### PR TITLE
Added an fzf-haiti command

### DIFF
--- a/sources/assets/zsh/aliases.d/fzf
+++ b/sources/assets/zsh/aliases.d/fzf
@@ -1,1 +1,3 @@
 alias fzf-wordlists='find /opt/rockyou.txt /opt/seclists /usr/share/wordlists /usr/share/wfuzz /usr/share/dirb -type f | fzf'
+alias fzf-haiti='(){ haiti -e $1 | fzf --ansi | grep -E -o " [0-9]*]" | cut -d "]" -f 1 | cut -d " " -f 2 ;}'
+alias hcat='(){ if [ -f "$1" ]; then hashcat -m $(fzf-haiti $(head -n 1 "$1")) "$1" $(fzf-wordlists) "${@:2}"; elif [ -n "$1" ]; then hashcat -m $(fzf-haiti "$1") "$1" $(fzf-wordlists) "${@:2}"; fi ;}'

--- a/sources/assets/zsh/history.d/hashcat
+++ b/sources/assets/zsh/history.d/hashcat
@@ -6,3 +6,5 @@ hashcat --hash-type 2100 --attack-mode 0 '$DCC2$10240#user#bb38628253e7681553b72
 hashcat --hash-type 1000 --attack-mode 0 --username "$DOMAIN".ntds `fzf-wordlists`
 hashcat --hash-type 13100 --attack-mode 0 Kerberoastables.txt `fzf-wordlists`
 hashcat --hash-type 18200 --attack-mode 0 ASREProastables.txt `fzf-wordlists`
+hcat '$DCC2$10240#user#bb38628253e7681553b72e7da3adf305'
+hcat Kerberoastables.txt

--- a/sources/assets/zsh/zshrc
+++ b/sources/assets/zsh/zshrc
@@ -84,15 +84,3 @@ else
   [ -d /opt/my-resources/setup/zsh ] || mkdir -p /opt/my-resources/setup/zsh
   cp /.exegol/skel/zsh/zshrc /opt/my-resources/setup/zsh/zshrc
 fi
-
-fzf-haiti () {
-    haiti -e "$1" | fzf --ansi | grep -E -o ' [0-9]*]' | cut -d ']' -f 1 | cut -d ' ' -f 2
-}
-
-hashcat2 () {
-    hash="$1"
-    shift 1
-    hashcat -m `fzf-haiti "$hash"` "$hash" `fzf-wordlists` "$@"
-}
-
-alias hcat='hashcat2'

--- a/sources/assets/zsh/zshrc
+++ b/sources/assets/zsh/zshrc
@@ -84,3 +84,15 @@ else
   [ -d /opt/my-resources/setup/zsh ] || mkdir -p /opt/my-resources/setup/zsh
   cp /.exegol/skel/zsh/zshrc /opt/my-resources/setup/zsh/zshrc
 fi
+
+fzf-haiti () {
+    haiti -e "$1" | fzf --ansi | grep -E -o ' [0-9]*]' | cut -d ']' -f 1 | cut -d ' ' -f 2
+}
+
+hashcat2 () {
+    hash="$1"
+    shift 1
+    hashcat -m `fzf-haiti "$hash"` "$hash" `fzf-wordlists` "$@"
+}
+
+alias hcat='hashcat2'


### PR DESCRIPTION
# Description

Add a an `fzf-haiti` command to search for hash type, for example while using `hashcat`.

Run a `hashcat` crack:
![image](https://github.com/ThePorgs/Exegol-images/assets/10383569/814bf6c5-8fc0-4a0d-b497-9b6980672921)

Choose a hash mode using `fzf`:
![image](https://github.com/ThePorgs/Exegol-images/assets/10383569/370f570d-b2d6-4727-a65e-d2aecce87e07)

Choose the wordlist using `fzf`:
![image](https://github.com/ThePorgs/Exegol-images/assets/10383569/6c77f71d-024e-4ee1-9baf-8147a07b41fa)

![image](https://github.com/ThePorgs/Exegol-images/assets/10383569/a99a9810-2161-4a8b-a886-beb23fa880da)

# Related issues

N / A

# Point of attention

I know `hashcat` automatically select hash type when he can decide, but this doesn't work for a lot of hash type that looks the same.
