### PR TITLE
Fix 7zip2john

### DIFF
--- a/sources/install/package_cracking.sh
+++ b/sources/install/package_cracking.sh
@@ -29,9 +29,11 @@ function install_john() {
     git -C /opt/tools/ clone --depth 1 https://github.com/openwall/john
     cd /opt/tools/john/src || exit
     ./configure --disable-native-tests && make
+    yes|cpan install Compress::Raw::Lzma
     add-aliases john-the-ripper
     add-history john-the-ripper
     add-test-command "john --help"
+    add-test-command "7z2john.pl|& grep 'Usage'"
     add-to-list "john,https://github.com/openwall/john,John the Ripper password cracker."
 }
 


### PR DESCRIPTION
# Description

Fix 7zip2john

Before :
```
> 7z2john.pl 
Can't locate Compress/Raw/Lzma.pm in @INC (you may need to install the Compress::Raw::Lzma module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/aarch64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /opt/tools/john/run/7z2john.pl line 6.
BEGIN failed--compilation aborted at /opt/tools/john/run/7z2john.pl line 6.
```

Now :
```
> 7z2john.pl       
Usage: /opt/tools/john/run/7z2john.pl <7-Zip file>...
```