### PR TITLE
Fixed 7z2john

### DIFF
--- a/sources/install/package_cracking.sh
+++ b/sources/install/package_cracking.sh
@@ -25,6 +25,7 @@ function install_cracking_apt_tools() {
 function install_john() {
     colorecho "Installing john the ripper"
     git -C /opt/tools/ clone --depth 1 https://github.com/openwall/john
+    apt install libcompress-raw-lzma-perl # Necessary to make 7z2john work, https://github.com/openwall/john/blob/b8b5d164d0b3bb15401d837cd4577905b6214ad0/run/7z2john.pl#L33
     add-aliases john-the-ripper
     add-history john-the-ripper
     add-test-command "john --help"

--- a/sources/install/package_cracking.sh
+++ b/sources/install/package_cracking.sh
@@ -25,7 +25,7 @@ function install_cracking_apt_tools() {
 function install_john() {
     colorecho "Installing john the ripper"
     git -C /opt/tools/ clone --depth 1 https://github.com/openwall/john
-    apt install libcompress-raw-lzma-perl # Necessary to make 7z2john work, https://github.com/openwall/john/blob/b8b5d164d0b3bb15401d837cd4577905b6214ad0/run/7z2john.pl#L33
+    apt-get install -y libcompress-raw-lzma-perl # Necessary to make 7z2john work, https://github.com/openwall/john/blob/b8b5d164d0b3bb15401d837cd4577905b6214ad0/run/7z2john.pl#L33
     add-aliases john-the-ripper
     add-history john-the-ripper
     add-test-command "john --help"


### PR DESCRIPTION
# Description

When running `7z2john`, I got this error (on both nightly and full):
```
Can't locate Compress/Raw/Lzma.pm in @INC (you may need to install the Compress::Raw::Lzma module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/x86_64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /opt/tools/john/run/7z2john.pl line 6.
BEGIN failed--compilation aborted at /opt/tools/john/run/7z2john.pl line 6.
```

To fix this, one needs to install this lib:
```
apt-get install -y libcompress-raw-lzma-perl
```

Ref: https://github.com/openwall/john/blob/b8b5d164d0b3bb15401d837cd4577905b6214ad0/run/7z2john.pl#L33

# Related issues

N / A

# Point of attention

N / A
