### PR TITLE
fix: allow the shell to split arguments to kill

### DIFF
--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -353,7 +353,7 @@ function post_install() {
         echo "Listening processes detected"
         ss -lnpt
         echo "Kill processes"
-        kill -9 "$listening_processes"
+        kill -9 $listening_processes
     fi
     add-test-command "if [[ $(sudo ss -lnpt | tail -n +2 | wc -l) -ne 0 ]]; then ss -lnpt && false;fi"
     colorecho "Sorting tools list"

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -353,6 +353,7 @@ function post_install() {
         echo "Listening processes detected"
         ss -lnpt
         echo "Kill processes"
+        # shellcheck disable=SC2086
         kill -9 $listening_processes
     fi
     add-test-command "if [[ $(sudo ss -lnpt | tail -n +2 | wc -l) -ne 0 ]]; then ss -lnpt && false;fi"


### PR DESCRIPTION
# Description
If `$listening_processes` holds multiple ids, quoting them leads to them being passed to `kill` as one argument instead of multiple.