### PR TITLE
[Fix] - CMSMAP exploitdb path

### DIFF
--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -272,9 +272,7 @@ function install_drupwn() {
 function install_cmsmap() {
     colorecho "Installing CMSmap"
     python3 -m pipx install git+https://github.com/Dionach/CMSmap.git
-    # TODO: Config ?
-    # exploit-db path is required (misc package -> searchsploit)
-    # cmsmap -U PC
+    sed -i 's|/usr/share/exploitdb/|/opt/tools/exploitdb/|g' /root/.local/pipx/venvs/cmsmap/lib/python3.9/site-packages/cmsmap/cmsmap.conf
     add-history cmsmap
     add-test-command "cmsmap --help; cmsmap --help |& grep 'Post Exploitation'"
     add-to-list "cmsmap,https://github.com/Dionach/CMSmap,Tool for security audit of web content management systems."


### PR DESCRIPTION
# Description

> when I was using the tool I noticed that the path specified in the configuration file was incorrect, which prevents it from being used.

This is just a small contribution and not the cleanest but at least it works

![image](https://github.com/ThePorgs/Exegol-images/assets/15458329/42a5b6a8-d851-4f6c-9ad9-129b7722abfe)
