### PR TITLE
Add new Bloodhound customqueries

### DIFF
--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -1,6 +1,70 @@
 {
     "queries": [
         {
+            "name": "Find more privileged groups",
+            "category": "High Value Targets",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (g:Group) WHERE g.objectid =~ '.*-(512|517|518|519|520|521|522|526|527|(?i)S-1-5-32-(544|547|548|549|550|551|552|556|557|580)|(?i)S-1-5-9)$' OR toUpper(g.samaccountname) = 'DNSADMINS' RETURN g"
+            }]
+        },
+        {
+            "name": "(Warning: edits the DB) Mark more privileged groups as HVT",
+            "category": "High Value Targets",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (g:Group) WHERE g.objectid =~ '.*-(512|517|518|519|520|521|522|526|527|(?i)S-1-5-32-(544|547|548|549|550|551|552|556|557|580)|(?i)S-1-5-9)$' OR toUpper(g.samaccountname) = 'DNSADMINS' SET g.highvalue=TRUE RETURN g"
+            }]
+        },
+        {
+            "name": "Find low value members of High Value Target Groups (1 hop)",
+            "category": "High Value Targets",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(m {highvalue: FALSE})-[:MemberOf]->(g:Group {highvalue: TRUE}) RETURN p"
+            }]
+        },
+        {
+            "name": "(Warning: edits the DB) Mark low value members of High Value Target Groups as HVT (1 hop)",
+            "category": "High Value Targets",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(o {highvalue: FALSE})-[:MemberOf]->(g:Group {highvalue: TRUE}) SET o.highvalue=TRUE RETURN p"
+            }]
+        },
+        {
+            "name": "Find objects containing names of some tier 0 software (SCCM, Veeam, ...)",
+            "category": "High Value Targets",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (o) WHERE (o.samaccountname =~ '(?i).*(?:sccm|veeam|boomgar|tivoli|altiris|varonis|vcenter|vsphere|esx).*') RETURN o"
+            }]
+        },
+        {
+            "name": "(Warning: edits the DB) Mark objects containing names of some tier 0 software (SCCM, Veeam, ...) as HVT",
+            "category": "High Value Targets",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (o) WHERE (o.samaccountname =~ '(?i).*(?:sccm|veeam|boomgar|tivoli|altiris|varonis|vcenter|vsphere|esx).*') SET o.highvalue=TRUE RETURN o"
+            }]
+        },
+        {
+            "name": "Find low value objects with ACLs on high value objects (1 hop, max 200, Heavy)",
+            "category": "High Value Targets",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=((a {highvalue: FALSE})-[r]->(b {highvalue: TRUE})) WHERE NOT (type(r) = 'Contains') RETURN p LIMIT 200"
+            }]
+        },
+        {
+            "name": "(Warning: edits the DB) Mark low value objects with ACLs on high value objects as HVT (1 hop, max 200, Heavy)",
+            "category": "High Value Targets",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=((a {highvalue: FALSE})-[r]->(b {highvalue: TRUE})) WHERE NOT (type(r) = 'Contains') SET a.highvalue=TRUE RETURN p LIMIT 200"
+            }]
+        },
+        {
             "name": "Owned objects",
             "category": "Owned Objects",
             "queryList": [{
@@ -166,7 +230,7 @@
             "category": "Kerberos Delegations",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c {unconstraineddelegation:true}) return c"
+                "query": "MATCH (c {unconstraineddelegation:true}) RETURN c"
             }]
         },
         {
@@ -174,7 +238,7 @@
             "category": "Kerberos Delegations",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c) WHERE NOT c.allowedtodelegate IS NULL AND c.trustedtoauth=true return c"
+                "query": "MATCH (c) WHERE NOT c.allowedtodelegate IS NULL AND c.trustedtoauth=true RETURN c"
             }]
         },
         {
@@ -182,7 +246,7 @@
             "category": "Kerberos Delegations",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c) WHERE NOT c.allowedtodelegate IS NULL AND c.trustedtoauth=false return c"
+                "query": "MATCH (c) WHERE NOT c.allowedtodelegate IS NULL AND c.trustedtoauth=false RETURN c"
             }]
         },
         {
@@ -218,22 +282,42 @@
             }]
         },
         {
-            "name":"Between enabled users (max 200)",
+            "name":"Between users (1 hop, max 200)",
             "category":"Weak ACLs",
             "queryList":[
                 {
                     "final":true,
-                    "query":"MATCH p=(u1:User { enabled: TRUE } )-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink*1..]->(u2:User { enabled: TRUE }) WHERE NOT(u1.name STARTS WITH 'MSOL_') RETURN p LIMIT 200"
+                    "query":"MATCH p=(u1:User { enabled: TRUE } )-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink]->(u2:User) WHERE NOT(u1.name STARTS WITH 'MSOL_') RETURN p LIMIT 200"
                 }
             ]
         },
         {
-            "name":"Between enabled computers (max 200)",
+            "name":"Between users (3 hops, max 200)",
             "category":"Weak ACLs",
             "queryList":[
                 {
                     "final":true,
-                    "query":"MATCH p=(c1:Computer {enabled: TRUE})-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink*1..]->(c2:Computer {enabled: TRUE}) WHERE NOT(c1.name STARTS WITH 'MSOL_') RETURN p LIMIT 200"
+                    "query":"MATCH p=(u1:User { enabled: TRUE } )-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink*1..3]->(u2:User) WHERE NOT(u1.name STARTS WITH 'MSOL_') RETURN p LIMIT 200"
+                }
+            ]
+        },
+        {
+            "name":"Between computers (1 hop, max 200)",
+            "category":"Weak ACLs",
+            "queryList":[
+                {
+                    "final":true,
+                    "query":"MATCH p=(c1:Computer {enabled: TRUE})-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink]->(c2:Computer) WHERE NOT(c1.name STARTS WITH 'MSOL_') RETURN p LIMIT 200"
+                }
+            ]
+        },
+        {
+            "name":"Between computers (3 hops, max 200)",
+            "category":"Weak ACLs",
+            "queryList":[
+                {
+                    "final":true,
+                    "query":"MATCH p=(c1:Computer {enabled: TRUE})-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink*1..3]->(c2:Computer) WHERE NOT(c1.name STARTS WITH 'MSOL_') RETURN p LIMIT 200"
                 }
             ]
         },
@@ -246,22 +330,42 @@
             }]
         },
         {
-            "name":"Between enabled users and computers (max 200)",
+            "name":"Between enabled users and computers (1 hop, max 200)",
             "category":"Weak ACLs",
             "queryList":[
                 {
                     "final":true,
-                    "query":"MATCH p=(u:User {enabled: TRUE})-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink*1..]->(c:Computer {enabled: TRUE}) WHERE NOT(u.name STARTS WITH 'MSOL_') RETURN p LIMIT 200"
+                    "query":"MATCH p=(u:User {enabled: TRUE})-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink]->(c:Computer) WHERE NOT(u.name STARTS WITH 'MSOL_') RETURN p LIMIT 200"
                 }
             ]
         },
         {
-            "name":"Between enabled computers and users (max 200)",
+            "name":"Between enabled users and computers (3 hops, max 200)",
             "category":"Weak ACLs",
             "queryList":[
                 {
                     "final":true,
-                    "query":"MATCH p=(c:Computer {enabled: TRUE})-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink*1..]->(u:User {enabled: TRUE}) WHERE NOT(u.name STARTS WITH 'MSOL_') RETURN p LIMIT 200"
+                    "query":"MATCH p=(u:User {enabled: TRUE})-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink*1..3]->(c:Computer) WHERE NOT(u.name STARTS WITH 'MSOL_') RETURN p LIMIT 200"
+                }
+            ]
+        },
+        {
+            "name":"Between enabled computers and users (1 hop, max 200)",
+            "category":"Weak ACLs",
+            "queryList":[
+                {
+                    "final":true,
+                    "query":"MATCH p=(c:Computer {enabled: TRUE})-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink]->(u:User) WHERE NOT(u.name STARTS WITH 'MSOL_') RETURN p LIMIT 200"
+                }
+            ]
+        },
+        {
+            "name":"Between enabled computers and users (3 hops, max 200)",
+            "category":"Weak ACLs",
+            "queryList":[
+                {
+                    "final":true,
+                    "query":"MATCH p=(c:Computer {enabled: TRUE})-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink*1..3]->(u:User) WHERE NOT(u.name STARTS WITH 'MSOL_') RETURN p LIMIT 200"
                 }
             ]
         },
@@ -274,12 +378,22 @@
             }]
         },
         {
-            "name":"Miscellaneous direct ACLs (max 200)",
+            "name":"Miscellaneous direct ACLs from enabled objects (1 hop, max 200)",
             "category":"Weak ACLs",
             "queryList":[
                 {
                     "final":true,
-                    "query":"MATCH p=(u1)-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink*1..]->(u2) WHERE NOT(u1.name STARTS WITH 'MSOL_') AND NOT(u2.name STARTS WITH 'MSOL_') AND NOT(u1.name CONTAINS 'ADMIN') AND NOT(u2.name CONTAINS 'ADMIN') RETURN p LIMIT 200"
+                    "query":"MATCH p=(u1 {enabled: TRUE})-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink|Enroll|ManageCa|ManageCertificates]->(u2) WHERE NOT(u1.name STARTS WITH 'MSOL_') AND NOT(u2.name STARTS WITH 'MSOL_') AND NOT(u1.name CONTAINS 'ADMIN') AND NOT(u2.name CONTAINS 'ADMIN') RETURN p LIMIT 200"
+                }
+            ]
+        },
+        {
+            "name":"Miscellaneous direct ACLs from enabled objects (3 hops, max 200)",
+            "category":"Weak ACLs",
+            "queryList":[
+                {
+                    "final":true,
+                    "query":"MATCH p=(u1 {enabled: TRUE})-[:AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|AddSelf|WriteSPN|AddKeyCredentialLink|Enroll|ManageCa|ManageCertificates*1..3]->(u2) WHERE NOT(u1.name STARTS WITH 'MSOL_') AND NOT(u2.name STARTS WITH 'MSOL_') AND NOT(u1.name CONTAINS 'ADMIN') AND NOT(u2.name CONTAINS 'ADMIN') RETURN p LIMIT 200"
                 }
             ]
         },
@@ -288,7 +402,7 @@
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(a:Computer)-[r:HasSession]->(b:User) WITH a,b,r MATCH p=shortestPath((b)-[:AdminTo|MemberOf*1..]->(a)) RETURN p",
+                "query": "MATCH p=(a:Computer {enabled: TRUE})-[r:HasSession]->(b:User {enabled: TRUE}) WITH a,b,r MATCH p=shortestPath((b)-[:AdminTo|MemberOf*1..]->(a)) RETURN p",
                 "allowCollapse": true
             }]
         },
@@ -297,15 +411,23 @@
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(m:User)-[r:AdminTo]->(n:Computer) RETURN p"
+                "query": "MATCH p=(m:User {enabled: TRUE})-[r:AdminTo]->(n:Computer {enabled: TRUE}) RETURN p"
             }]
         },
         {
-            "name": "Domain admin sessions",
+            "name": "Domain admins sessions",
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User)-[:MemberOf]->(g:Group) WHERE g.objectid ENDS WITH '-512' MATCH p = (c:Computer)-[:HasSession]->(n) RETURN p"
+                "query": "MATCH (n:User {enabled: TRUE})-[:MemberOf]->(g:Group) WHERE g.objectid ENDS WITH '-512' MATCH p = (c:Computer {enabled: TRUE})-[:HasSession]->(n) RETURN p"
+            }]
+        },
+        {
+            "name": "Privileged users sessions",
+            "category": "Admins",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (n:User {enabled: TRUE})-[:MemberOf*1..]->(g:Group {highvalue: TRUE}) MATCH p = (c:Computer {enabled: TRUE})-[:HasSession]->(n) RETURN p"
             }]
         },
         {
@@ -317,11 +439,19 @@
             }]
         },
         {
-            "name": "Enabled users members of high value groups, not sensitive and not Protected Users",
+            "name": "Enabled Domain/Enterprise Administrators, not sensitive for delegation and not members of Protected Users",
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User)-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '(?i)S-1-5-.*-525' WITH COLLECT (u.name) as protectedUsers MATCH p=(u2:User {enabled: TRUE} )-[:MemberOf*1..]->(g2:Group {highvalue: TRUE}) WHERE u2.sensitive=false AND NOT u2.name IN protectedUsers RETURN p"
+                "query": "MATCH (u:User {enabled: TRUE, admincount: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-525$' WITH COLLECT(u.objectid) as protectedUsers MATCH p=(u2:User {enabled: TRUE, admincount: TRUE, sensitive: FALSE})-[:MemberOf*1..]->(g2:Group) WHERE NOT u2.objectid IN protectedUsers AND g2.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' RETURN p"
+            }]
+        },
+        {
+            "name": "Enabled users, members of high value groups, not sensitive for delegation and not members of Protected Users (Heavy)",
+            "category": "Admins",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (u:User {enabled: TRUE, admincount: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-525$' WITH COLLECT (u.objectid) as protectedUsers MATCH p=(u2:User {enabled: TRUE, sensitive: FALSE})-[:MemberOf*1..]->(g2:Group {highvalue: TRUE}) WHERE NOT u2.objectid IN protectedUsers RETURN p"
             }]
         },
         {
@@ -420,7 +550,7 @@
             "category": "Users",
             "queryList": [{
                 "final": true,
-                "query": "Match p=(u:User)-[:MemberOf]->(g:Group) WHERE toUPPER (g.name) CONTAINS 'VPN' return p"
+                "query": "Match p=(u:User)-[:MemberOf]->(g:Group) WHERE toUPPER (g.name) CONTAINS 'VPN' RETURN p"
             }]
         },
         {
@@ -428,7 +558,31 @@
             "category": "GPOs",
             "queryList": [{
                 "final": true,
-                "query": "Match (n:GPO) RETURN n"
+                "query": "MATCH (g:GPO) RETURN g"
+            }]
+        },
+        {
+            "name": "(Warning: edits the DB) Mark all GPOs as High Value Target",
+            "category": "GPOs",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (g:GPO) SET g.highvalue=TRUE RETURN g"
+            }]
+        },
+        {
+            "name": "Find if any low value object has interesting permissions against a GPO (1 hop)",
+            "category": "GPOs",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(o {highvalue: FALSE})-[:AllExtendedRights|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|GpLink]->(g:GPO) RETURN p"
+            }]
+        },
+        {
+            "name": "(Warning: edits the DB) Mark any low value object with interesting permissions against a GPO as HVT (1 hop)",
+            "category": "GPOs",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(o {highvalue: FALSE})-[:AllExtendedRights|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|GpLink]->(g:GPO) SET o.highvalue=TRUE RETURN p"
             }]
         },
         {
@@ -541,7 +695,7 @@
                 "allowCollapse": true
             }]
         },
-                {
+        {
             "name": "Top 20 nodes with most first degree object controls",
             "category": "Top Ten",
             "queryList": [{
@@ -564,7 +718,7 @@
             "category": "RDP",
             "queryList": [{
                 "final": true,
-                "query": "match p=(g:Group)-[:CanRDP]->(c:Computer) where g.objectid ENDS WITH '-513' return p"
+                "query": "MATCH p=(g:Group)-[:CanRDP]->(c:Computer) where g.objectid ENDS WITH '-513' RETURN p"
             }]
         },
         {
@@ -572,7 +726,7 @@
             "category": "RDP",
             "queryList": [{
                 "final": true,
-                "query": "match p=(g:Group)-[:CanRDP]->(c:Computer) where g.name STARTS WITH 'DOMAIN USERS' AND c.operatingsystem CONTAINS 'Server' return p",
+                "query": "MATCH p=(g:Group)-[:CanRDP]->(c:Computer) where g.name STARTS WITH 'DOMAIN USERS' AND c.operatingsystem CONTAINS 'Server' RETURN p",
                 "allowCollapse": true
             }]
         },
@@ -673,6 +827,14 @@
             }]
         },
         {
+            "name": "Find objects with the ManageCa or ManageCertificates right on Certificate Authorities",
+            "category": "Certificates",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(o)-[:ManageCa|ManageCertificates]->(c:GPO {type: 'Enrollment Service'}) RETURN p"
+            }]
+        },
+        {
             "name": "Show Enrollment Rights for Certificate Template",
             "category": "Certificates",
             "queryList": [{
@@ -682,7 +844,7 @@
               },
               {
                 "final": true,
-                "query": "MATCH p=(g)-[:Enroll|AutoEnroll]->(n:GPO {name:$result}) WHERE n.type = 'Certificate Template' return p",
+                "query": "MATCH p=(g)-[:Enroll|AutoEnroll]->(n:GPO {name:$result}) WHERE n.type = 'Certificate Template' RETURN p",
                 "allowCollapse": false
             }]
         },
@@ -696,7 +858,7 @@
               },
               {
                 "final": true,
-                "query": "MATCH p=(g)-[:ManageCa|ManageCertificates|Auditor|Operator|Read|Enroll]->(n:GPO {name:$result}) return p",
+                "query": "MATCH p=(g)-[:ManageCa|ManageCertificates|Auditor|Operator|Read|Enroll]->(n:GPO {name:$result}) RETURN p",
                 "allowCollapse": false
             }]
         },
@@ -713,7 +875,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=allShortestPaths((g {owned:true})-[*1..]->(n:GPO)) WHERE  g<>n and n.type = 'Certificate Template' and n.`Enrollee Supplies Subject` = true and n.`Client Authentication` = true and n.`Enabled` = true return p"
+                "query": "MATCH p=allShortestPaths((g {owned:true})-[*1..]->(n:GPO)) WHERE  g<>n and n.type = 'Certificate Template' and n.`Enrollee Supplies Subject` = true and n.`Client Authentication` = true and n.`Enabled` = true RETURN p"
             }]
         },
         {
@@ -729,7 +891,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=allShortestPaths((g {owned:true})-[*1..]->(n:GPO)) WHERE  g<>n and n.type = 'Certificate Template' and n.`Enabled` = true and (n.`Extended Key Usage` = [] or 'Any Purpose' IN n.`Extended Key Usage`) return p"
+                "query": "MATCH p=allShortestPaths((g {owned:true})-[*1..]->(n:GPO)) WHERE  g<>n and n.type = 'Certificate Template' and n.`Enabled` = true and (n.`Extended Key Usage` = [] or 'Any Purpose' IN n.`Extended Key Usage`) RETURN p"
             }]
         },
         {
@@ -745,7 +907,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=allShortestPaths((g {owned:true})-[*1..]->(n:GPO)) WHERE  g<>n and n.type = 'Certificate Template' and n.`Enabled` = true and (n.`Extended Key Usage` = [] or 'Any Purpose' IN n.`Extended Key Usage` or 'Certificate Request Agent' IN n.`Extended Key Usage`) return p"
+                "query": "MATCH p=allShortestPaths((g {owned:true})-[*1..]->(n:GPO)) WHERE  g<>n and n.type = 'Certificate Template' and n.`Enabled` = true and (n.`Extended Key Usage` = [] or 'Any Purpose' IN n.`Extended Key Usage` or 'Certificate Request Agent' IN n.`Extended Key Usage`) RETURN p"
             }]
         },
         {
@@ -761,7 +923,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=allShortestPaths((g {owned:true})-[r*1..]->(n:GPO)) WHERE g<>n and n.type = 'Certificate Template' and n.Enabled = true and NONE(x in relationships(p) WHERE type(x) = 'Enroll' or type(x) = 'AutoEnroll') return p"
+                "query": "MATCH p=allShortestPaths((g {owned:true})-[r*1..]->(n:GPO)) WHERE g<>n and n.type = 'Certificate Template' and n.Enabled = true and NONE(x in relationships(p) WHERE type(x) = 'Enroll' or type(x) = 'AutoEnroll') RETURN p"
             }]
         },
         {
@@ -822,7 +984,7 @@
             "queryList": [
                 {
                 "final": true,
-                "query": "MATCH p=allShortestPaths((g {owned:true})-[r*1..]->(n:GPO)) WHERE n.type = 'Certificate Template' and g<>n and 'NoSecurityExtension' in n.`Enrollment Flag` and n.`Enabled` = true and NONE(rel in r WHERE type(rel) in ['EnabledBy','Read','ManageCa','ManageCertificates']) return p"
+                "query": "MATCH p=allShortestPaths((g {owned:true})-[r*1..]->(n:GPO)) WHERE n.type = 'Certificate Template' and g<>n and 'NoSecurityExtension' in n.`Enrollment Flag` and n.`Enabled` = true and NONE(rel in r WHERE type(rel) in ['EnabledBy','Read','ManageCa','ManageCertificates']) RETURN p"
                 }
             ]
         },
@@ -832,7 +994,7 @@
 			"queryList": [
 				{
 					"final": true,
-					"query": "match (u1:User) WHERE u1.plaintext=True MATCH p1=(u1)-[:CanRDP*1..]->(c:Computer) RETURN u1",
+					"query": "MATCH (u1:User) WHERE u1.plaintext=True MATCH p1=(u1)-[:CanRDP*1..]->(c:Computer) RETURN u1",
 					"allowCollapse": true
 				}
 			]
@@ -843,7 +1005,7 @@
 			"queryList": [
 				{
 					"final": true,
-					"query": "match (u1:User) WHERE u1.plaintext=True MATCH p=(u1:User)-[r:MemberOf*1..]->(m:Group {highvalue:true}) RETURN u1",
+					"query": "MATCH (u1:User) WHERE u1.plaintext=True MATCH p=(u1:User)-[r:MemberOf*1..]->(m:Group {highvalue:true}) RETURN u1",
 					"allowCollapse": true
 				}
 			]
@@ -854,7 +1016,7 @@
 			"queryList": [
 				{
 					"final": true,
-					"query": "match (u1:User) WHERE u1.plaintext=True AND u1.hasspn=True RETURN u1",
+					"query": "MATCH (u1:User) WHERE u1.plaintext=True AND u1.hasspn=True RETURN u1",
 					"allowCollapse": true
 				}
 			]
@@ -876,7 +1038,7 @@
 			"queryList": [
 				{
 					"final": true,
-					"query": "match (u1:User) WHERE u1.plaintextpassword =~ \"([Ww]inter.*|[sS]pring.*|[sS]ummer.*|[fF]all.*)\" match p=(u1:User)-[r:AdminTo]->(n:Computer) RETURN p",
+					"query": "MATCH (u1:User) WHERE u1.plaintextpassword =~ \"([Ww]inter.*|[sS]pring.*|[sS]ummer.*|[fF]all.*)\" MATCH p=(u1:User)-[r:AdminTo]->(n:Computer) RETURN p",
 					"allowCollapse": true
 				}
 			]
@@ -887,7 +1049,7 @@
 			"queryList": [
 				{
 					"final": true,
-					"query": "match (u1:User) WHERE u1.plaintextpassword =~ \"([Ww]inter.*|[sS]pring.*|[sS]ummer.*|[fF]all.*)\" MATCH p=shortestPath((u1:User)-[*1..]->(n {highvalue:true})) WHERE  u1<>n return u1 LIMIT 25",
+					"query": "MATCH (u1:User) WHERE u1.plaintextpassword =~ \"([Ww]inter.*|[sS]pring.*|[sS]ummer.*|[fF]all.*)\" MATCH p=shortestPath((u1:User)-[*1..]->(n {highvalue:true})) WHERE u1<>n RETURN u1 LIMIT 25",
 					"allowCollapse": true
 				}
 			]
@@ -909,7 +1071,7 @@
 			"queryList": [
 				{
 					"final": true,
-					"query": "match (u1:User) WHERE u1.plaintextpassword =~ \"(.*[pP][aA@][sS$][sS$][wW][oO0][rR][dD].*)\" match p=(u1:User)-[r:AdminTo]->(n:Computer) RETURN p",
+					"query": "MATCH (u1:User) WHERE u1.plaintextpassword =~ \"(.*[pP][aA@][sS$][sS$][wW][oO0][rR][dD].*)\" MATCH p=(u1:User)-[r:AdminTo]->(n:Computer) RETURN p",
 					"allowCollapse": true
 				}
 			]
@@ -920,10 +1082,95 @@
 			"queryList": [
 				{
 					"final": true,
-					"query": "match (u1:User) WHERE u1.plaintextpassword =~ \"(.*[pP][aA@][sS$][sS$][wW][oO0][rR][dD].*)\"  MATCH p=shortestPath((u1:User)-[*1..]->(n {highvalue:true})) WHERE  u1<>n return u1 LIMIT 25",
+					"query": "MATCH (u1:User) WHERE u1.plaintextpassword =~ \"(.*[pP][aA@][sS$][sS$][wW][oO0][rR][dD].*)\"  MATCH p=shortestPath((u1:User)-[*1..]->(n {highvalue:true})) WHERE  u1<>n RETURN u1 LIMIT 25",
 					"allowCollapse": true
 				}
 			]
-		}
+		},
+        {
+            "name": "Add indexes to the database",
+            "category": "Indexes",
+            "queryList": [{
+                    "final": false,
+                    "title": "Add index on the property Base SamAccountName",
+                    "query": "CREATE INDEX BaseSamAccountNameIdx IF NOT EXISTS FOR (b:Base) on (b.samaccountname)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property Computer SamAccountName",
+                    "query": "CREATE INDEX ComputerSamAccountNameIdx IF NOT EXISTS FOR (c:Computer) on (c.samaccountname)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property User SamAccountName",
+                    "query": "CREATE INDEX UserSamAccountNameIdx IF NOT EXISTS FOR (u:User) on (u.samaccountname)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property Computer SamAccountName",
+                    "query": "CREATE INDEX ComputerOwnedIdx IF NOT EXISTS FOR (c:Computer) on (c.owned)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property User Owned",
+                    "query": "CREATE INDEX UserOwnedIdx IF NOT EXISTS FOR (u:User) on (u.owned)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property Group Owned",
+                    "query": "CREATE INDEX GroupOwnedIdx IF NOT EXISTS FOR (g:Group) on (g.owned)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property GPO Owned",
+                    "query": "CREATE INDEX GPOOwnedIdx IF NOT EXISTS FOR (g:GPO) on (g.owned)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property Computer Highvalue",
+                    "query": "CREATE INDEX ComputerHighValueIdx IF NOT EXISTS FOR (c:Computer) on (c.highvalue)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property User Highvalue",
+                    "query": "CREATE INDEX UserHighValueIdx IF NOT EXISTS FOR (u:User) on (u.highvalue)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property Group Highvalue",
+                    "query": "CREATE INDEX GroupHighValueIdx IF NOT EXISTS FOR (g:Group) on (g.highvalue)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property GPO Highvalue",
+                    "query": "CREATE INDEX GPOHighValueIdx IF NOT EXISTS FOR (g:GPO) on (g.highvalue)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property User Sensitive",
+                    "query": "CREATE INDEX UserSensitiveIdx IF NOT EXISTS FOR (u:User) on (u.sensitive)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property User Admincount",
+                    "query": "CREATE INDEX UserAdminCountIdx IF NOT EXISTS FOR (u:User) on (u.admincount)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property Computer Enabled",
+                    "query": "CREATE INDEX ComputerEnabledIdx IF NOT EXISTS FOR (c:Computer) on (c.enabled)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property User Enabled",
+                    "query": "CREATE INDEX UserEnabledIdx IF NOT EXISTS FOR (u:User) on (u.enabled)"
+                },
+                {
+                    "final": true,
+                    "title": "Add index on the property GPO Enabled",
+                    "query": "CREATE INDEX GPOEnabledIdx IF NOT EXISTS FOR (g:GPO) on (g.enabled)"
+                }
+            ]
+        }
     ]
 }


### PR DESCRIPTION
This PR adds a bunch of new customqueries for Bloodhound:
- Add a new category named `High Value Targets` to mark more groups and objects as HVT. There are other queries already present in the collection to mark objects such as Unconstrained objects as HVT, but I decided not to move them for clarity.
- In the Weak ACLs section, the filter on some destination Enabled objects is removed. A disabled object could indeed be interesting if the relation type is GenericAll.
- A few other misc queries
- An all-in-one query to add `indexes` to speed up queries execution time