### PR TITLE
Add some commands to zsh_history for Kerbrute

### DIFF
--- a/sources/assets/shells/history.d/kerbrute
+++ b/sources/assets/shells/history.d/kerbrute
@@ -1,3 +1,5 @@
-kerbrute userenum -d "$DOMAIN" usernames.txt
-kerbrute passwordspray -d "$DOMAIN" domain_users.txt Password123
-kerbrute bruteuser -d "$DOMAIN" passwords.lst thoffman
+kerbrute userenum --domain "$DOMAIN" usernames.txt
+kerbrute passwordspray --domain "$DOMAIN" domain_users.txt Password123
+kerbrute passwordspray --user-as-pass --domain "$DOMAIN" domain_users.txt
+kerbrute bruteuser --domain "$DOMAIN" passwords.lst thoffman
+kerbrute bruteforce --domain "$DOMAIN" user_password.lst


### PR DESCRIPTION
Add some commands to zsh history for Kerbrute and in particular the `user=pass` feature when password spraying.
I also replaced the `-d` flag by its `--domain` equivalent.