### PR TITLE
Fix Tmux parse issues when conf is created on Windows.

### DIFF
--- a/sources/assets/exegol/load_supported_setups.sh
+++ b/sources/assets/exegol/load_supported_setups.sh
@@ -63,7 +63,7 @@ function deploy_tmux() {
   colorecho "Deploying tmux"
   if [[ -d "$MY_SETUP_PATH/tmux" ]]; then
     # copy tmux/tmux.conf to ~/.tmux.conf
-    [[ -f "$MY_SETUP_PATH/tmux/tmux.conf" ]] && cp "$MY_SETUP_PATH/tmux/tmux.conf" ~/.tmux.conf
+    [[ -f "$MY_SETUP_PATH/tmux/tmux.conf" ]] && cp "$MY_SETUP_PATH/tmux/tmux.conf" ~/.tmux.conf && dos2unix ~/.tmux.conf
   else
     mkdir "$MY_SETUP_PATH/tmux" && chmod 770 "$MY_SETUP_PATH/tmux"
   fi


### PR DESCRIPTION
# Description

when creating tmux.conf on windows, \r\n will get added to EOL. This causes issues when tmux parses ~/.tmux.conf preventing you from being able to use TMUX. Adding dos2unix to convert the file so Tmux can properly parse file. 

# Related issues

N/A

