### PR TITLE
Add systemctl alias

### DIFF
--- a/sources/assets/shells/aliases.d/_init
+++ b/sources/assets/shells/aliases.d/_init
@@ -8,3 +8,4 @@ alias urldecode='python -c "import sys, urllib as ul; print ul.unquote_plus(sys.
 alias sed-empty-line='sed /^$/d'
 alias http-put-server='python3 /opt/resources/linux/http-put-server.py --bind 0.0.0.0'
 alias ws='cd /workspace'
+alias systemctl="echo 'Systemctl cannot be used inside the container. Please use the \"service\" command instead.' && false"


### PR DESCRIPTION
# Description

Add a systemctl alias to tell to use the service command

```bash
root@exegol-test /workspace # systemctl restart test
Systemctl cannot be used inside the container. Please use the "service" command instead.
```