### PR TITLE
Downgrade ruby version for evil-winrm (3.2.2 to 3.2.1)

### DIFF
--- a/sources/assets/shells/aliases.d/evil-winrm
+++ b/sources/assets/shells/aliases.d/evil-winrm
@@ -1,1 +1,1 @@
-alias evil-winrm='/usr/local/rvm/gems/ruby-3.2.2@evil-winrm/wrappers/ruby /usr/local/rvm/gems/ruby-3.2.2@evil-winrm/bin/evil-winrm'
+alias evil-winrm='/usr/local/rvm/gems/ruby-3.1.2@evil-winrm/wrappers/ruby /usr/local/rvm/gems/ruby-3.1.2@evil-winrm/bin/evil-winrm'

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -429,7 +429,7 @@ function install_krbrelayx() {
 
 function install_evilwinrm() {
     colorecho "Installing evil-winrm"
-    rvm use 3.2.2@evil-winrm --create
+    rvm use 3.1.2@evil-winrm --create
     gem install evil-winrm
     rvm use 3.2.2@default
     add-aliases evil-winrm


### PR DESCRIPTION
# Description

The ruby version for evil-winrm has been downgraded (**3.2.2** to **3.1.2**) as a function is deprecated and no longer exists on a more recent version (SSL use)

# Related issues

https://www.reddit.com/r/ruby/comments/1196wti/psa_and_a_little_rant_fileexists_direxists/

![image](https://github.com/ThePorgs/Exegol-images/assets/51704860/1595026b-9551-441e-93ba-af674989f7d4)
