### PR TITLE
OpenSSL activate legacy support

### DIFF
--- a/sources/assets/patches/openssl.patch
+++ b/sources/assets/patches/openssl.patch
@@ -1,0 +1,12 @@
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1

--- a/sources/assets/patches/openssl.patch
+++ b/sources/assets/patches/openssl.patch
@@ -1,9 +1,9 @@
-[openssl_init]
-providers = provider_sect
-
-[provider_sect]
+[exegol_provider]
 default = default_sect
 legacy = legacy_sect
+
+[openssl_init]
+providers = exegol_provider
 
 [default_sect]
 activate = 1

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -433,20 +433,7 @@ function install_evilwinrm() {
     gem install evil-winrm
     rvm use 3.2.2@default
     # https://forum.hackthebox.com/t/evil-winrm-error-on-connection-to-host/257342
-    echo """
-[openssl_init]
-providers = provider_sect
-
-[provider_sect]
-default = default_sect
-legacy = legacy_sect
-
-[default_sect]
-activate = 1
-
-[legacy_sect]
-activate = 1
-""" >> /etc/ssl/openssl.cnf
+    cat /root/sources/assets/patches/openssl.patch >> /etc/ssl/openssl.cnf
     add-aliases evil-winrm
     add-history evil-winrm
     add-test-command "evil-winrm --help"

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -432,8 +432,6 @@ function install_evilwinrm() {
     rvm use 3.1.2@evil-winrm --create
     gem install evil-winrm
     rvm use 3.2.2@default
-    # https://forum.hackthebox.com/t/evil-winrm-error-on-connection-to-host/257342
-    cat /root/sources/assets/patches/openssl.patch >> /etc/ssl/openssl.cnf
     add-aliases evil-winrm
     add-history evil-winrm
     add-test-command "evil-winrm --help"

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -432,6 +432,21 @@ function install_evilwinrm() {
     rvm use 3.1.2@evil-winrm --create
     gem install evil-winrm
     rvm use 3.2.2@default
+    # https://forum.hackthebox.com/t/evil-winrm-error-on-connection-to-host/257342
+    echo """
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1
+""" >> /etc/ssl/openssl.cnf
     add-aliases evil-winrm
     add-history evil-winrm
     add-test-command "evil-winrm --help"

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -509,5 +509,8 @@ function package_base() {
     # All programs using bundle will store their deps in vendor/
     bundle config path vendor/
 
-    # Remote Graphical Desktop installation
+    # OpenSSL activate legacy support
+    cat /root/sources/assets/patches/openssl.patch >> /etc/ssl/openssl.cnf
+    add-test-command "echo -n '1337' | openssl dgst -md4"
+    add-test-command "python3 -c 'import hashlib;print(hashlib.new(\"md4\", \"1337\".encode()).digest())'"
 }


### PR DESCRIPTION
# Description

* Openssl configuration issue that prevents SSL use with evil-winrm.
* MD4 support

# Related issues

* https://forum.hackthebox.com/t/evil-winrm-error-on-connection-to-host/257342/9
