### PR TITLE
TERM variable added to zshrc file for tmux compatibility

### DIFF
--- a/sources/assets/shells/zshrc
+++ b/sources/assets/shells/zshrc
@@ -30,6 +30,9 @@ setopt INC_APPEND_HISTORY
 setopt EXTENDED_HISTORY
 setopt HIST_FIND_NO_DUPS
 
+# TERM to prevent tmux not working with autosuggestion
+export TERM=xterm-256color
+
 # Color correction for zsh-syntax-highlighting
 ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=#626262'
 ZSH_HIGHLIGHT_STYLES[comment]='fg=#888888'


### PR DESCRIPTION
# Description

zsh autosuggestion does not work if TERM is screen. By default, tmux uses screen. If a user imports his tmux.conf config file, he won't get the autosuggestion. This fix forces the value of the TERM variable.

# Related issues

https://github.com/zsh-users/zsh-autosuggestions/issues/229