### PR TITLE
BloodHound customqueries: refacto for clarity, performance, fix and new queries

### DIFF
--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -69,7 +69,7 @@
             "category": "Owned Objects",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (m) WHERE m.owned=TRUE RETURN m"
+                "query": "MATCH (o {owned: TRUE}) RETURN o"
             }]
         },
         {
@@ -77,7 +77,7 @@
             "category": "Owned Objects",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User {owned:true}), (g:Group), p=(u)-[:MemberOf]->(g) RETURN p",
+                "query": "MATCH p=(u:User {owned: TRUE})-[:MemberOf]->(g:Group) RETURN p",
                 "props": {},
                 "allowCollapse": true
             }]
@@ -87,7 +87,7 @@
             "category": "Owned Objects",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (m:User) WHERE m.owned=TRUE WITH m MATCH p=(m)-[:MemberOf*1..]->(n:Group) RETURN p"
+                "query": "MATCH p=(u:User {owned: TRUE})-[:MemberOf*1..]->(g:Group) RETURN p"
             }]
         },
         {
@@ -95,7 +95,7 @@
             "category": "Owned Objects",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=shortestPath((n {owned:true})-[:MemberOf|HasSession|AdminTo|AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|CanRDP|ExecuteDCOM|AllowedToDelegate|ReadLAPSPassword|Contains|GpLink|AddAllowedToAct|AllowedToAct|SQLAdmin|ReadGMSAPassword|HasSIDHistory|CanPSRemote*1..5]->(m {highvalue:true})) WHERE NOT n=m RETURN p",
+                "query": "MATCH p=shortestPath((n {owned: TRUE})-[:MemberOf|HasSession|AdminTo|AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|CanRDP|ExecuteDCOM|AllowedToDelegate|ReadLAPSPassword|Contains|GpLink|AddAllowedToAct|AllowedToAct|SQLAdmin|ReadGMSAPassword|HasSIDHistory|CanPSRemote*1..5]->(m {highvalue: TRUE})) WHERE NOT n=m RETURN p",
                 "allowCollapse": true
             }]
         },
@@ -104,7 +104,7 @@
             "category": "Owned Objects",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=allShortestPaths((n {owned:true})-[:MemberOf|AdminTo|AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|ExecuteDCOM|AllowedToDelegate|ReadLAPSPassword|Contains|GpLink|AddAllowedToAct|AllowedToAct|SQLAdmin|ReadGMSAPassword|HasSIDHistory*1..5]->(m {highvalue:true})) WHERE NOT n=m RETURN p",
+                "query": "MATCH p=allShortestPaths((n {owned: TRUE})-[:MemberOf|AdminTo|AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|ExecuteDCOM|AllowedToDelegate|ReadLAPSPassword|Contains|GpLink|AddAllowedToAct|AllowedToAct|SQLAdmin|ReadGMSAPassword|HasSIDHistory*1..5]->(m {highvalue:true})) WHERE NOT n=m RETURN p",
                 "allowCollapse": true
             }]
         },
@@ -113,7 +113,7 @@
             "category": "Owned Objects",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=shortestPath((c {owned: true})-[*1..5]->(s)) WHERE NOT c = s RETURN p"
+                "query": "MATCH p=shortestPath((c {owned: TRUE})-[*1..5]->(s)) WHERE NOT c = s RETURN p"
             }]
         },
         {
@@ -121,7 +121,7 @@
             "category": "Owned Objects",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=shortestPath((c {owned: true})-[*1..3]->(s)) WHERE NOT c = s RETURN p"
+                "query": "MATCH p=shortestPath((c {owned: TRUE})-[*1..3]->(s)) WHERE NOT c = s RETURN p"
             }]
         },
         {
@@ -129,7 +129,7 @@
             "category": "Owned Objects",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(u:User {owned:true})-[r:AllExtendedRights|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|GpLink*1..]->(g:GPO) RETURN p"
+                "query": "MATCH p=(u:User {owned: TRUE})-[r:AllExtendedRights|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|GpLink*1..]->(g:GPO) RETURN p"
             }]
         },
         {
@@ -145,7 +145,7 @@
             "category": "Domains/Forests",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p = (a)-[r]->(b) WHERE NOT a.domain = b.domain AND r.isacl = True RETURN p"
+                "query": "MATCH p = (a)-[r]->(b) WHERE NOT a.domain = b.domain AND r.isacl = TRUE RETURN p"
             }]
         },
         {
@@ -169,68 +169,68 @@
             }]
         },
         {
-            "name": "Kerberoastable users with a path to DA",
+            "name": "Kerberoastable enabled users",
             "category": "Roasting",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User {hasspn:true}) MATCH (g:Group) WHERE g.objectid ENDS WITH '-512' MATCH p = shortestPath( (u)-[*1..]->(g) ) RETURN p"
-            }]
-        },
-        {
-            "name": "Kerberoastable users with a path to High Value",
-            "category": "Roasting",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (u:User {hasspn:true}),(n {highvalue:true}),p = shortestPath( (u)-[*1..]->(n) ) RETURN p"
-            }]
-        },
-        {
-            "name": " Kerberoastable users and where they are AdminTo",
-            "category": "Roasting",
-            "queryList": [{
-                "final": true,
-                "query": "OPTIONAL MATCH (u:User) WHERE u.hasspn=true OPTIONAL MATCH (u)-[r:AdminTo]->(c:Computer) RETURN u"
-            }]
-        },
-        {
-            "name": "Kerberoastable users who are members of high value groups",
-            "category": "Roasting",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (u:User)-[r:MemberOf*1..]->(g:Group) WHERE g.highvalue=true AND u.hasspn=true RETURN u"
-            }]
-        },
-        {
-            "name": "Kerberoastable users with passwords last set > 5 years ago",
-            "category": "Roasting",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (u:User) WHERE n.hasspn=true AND WHERE u.pwdlastset < (datetime().epochseconds - (1825 * 86400)) and NOT u.pwdlastset IN [-1.0, 0.0] RETURN u"
-            }]
-        },
-        {
-            "name": "Kerberoastable Users",
-            "category": "Roasting",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH (n:User)WHERE n.hasspn=true RETURN n",
+                "query": "MATCH (u:User {enabled: TRUE, hasspn: TRUE}) RETURN u",
                 "allowCollapse": false
             }]
         },
         {
-            "name": "AS-REProastable Users",
+            "name": "AS-REProastable enabled users",
             "category": "Roasting",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User {dontreqpreauth: true}) RETURN u"
+                "query": "MATCH (u:User {enabled: TRUE, dontreqpreauth: TRUE}) RETURN u"
             }]
         },
         {
-            "name": "Unconstrained Delegations",
+            "name": "Kerberoastable users with a path to DA",
+            "category": "Roasting",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p = shortestPath( (u:User {enabled: TRUE, hasspn: TRUE})-[*1..]->(g:Group) ) WHERE g.objectid ENDS WITH '-512' RETURN p"
+            }]
+        },
+        {
+            "name": "Kerberoastable enabled users with a path to High Value",
+            "category": "Roasting",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p = shortestPath( (u:User {enabled: TRUE, hasspn: TRUE})-[*1..]->(n {highvalue: TRUE}) ) RETURN p"
+            }]
+        },
+        {
+            "name": " Kerberoastable enabled users and where they are AdminTo",
+            "category": "Roasting",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p = shortestPath((u:User {enabled: TRUE, hasspn:TRUE})-[:AdminTo]->(c:Computer {enabled: TRUE})) RETURN p"
+            }]
+        },
+        {
+            "name": "Kerberoastable enabled users who are members of high value groups",
+            "category": "Roasting",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p = shortestPath((u:User {enabled: TRUE, hasspn: TRUE})-[:MemberOf*1..]->(g:Group {highvalue: TRUE})) RETURN p"
+            }]
+        },
+        {
+            "name": "Kerberoastable enabled users with passwords last set > 5 years ago",
+            "category": "Roasting",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (u:User {enabled: TRUE, hasspn: TRUE}) WHERE u.pwdlastset < (datetime().epochseconds - (1825 * 86400)) AND NOT u.pwdlastset IN [-1.0, 0.0] RETURN u"
+            }]
+        },
+        {
+            "name": "Unconstrained Delegations for enabled computers",
             "category": "Kerberos Delegations",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c {unconstraineddelegation:true}) RETURN c"
+                "query": "MATCH (c {enabled: TRUE, unconstraineddelegation: TRUE}) RETURN c"
             }]
         },
         {
@@ -238,7 +238,7 @@
             "category": "Kerberos Delegations",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c) WHERE NOT c.allowedtodelegate IS NULL AND c.trustedtoauth=true RETURN c"
+                "query": "MATCH (c) WHERE NOT c.allowedtodelegate IS NULL AND c.trustedtoauth=TRUE RETURN c"
             }]
         },
         {
@@ -246,7 +246,7 @@
             "category": "Kerberos Delegations",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c) WHERE NOT c.allowedtodelegate IS NULL AND c.trustedtoauth=false RETURN c"
+                "query": "MATCH (c) WHERE NOT c.allowedtodelegate IS NULL AND c.trustedtoauth=FALSE RETURN c"
             }]
         },
         {
@@ -254,7 +254,7 @@
             "category": "Kerberos Delegations",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(u)-[:AllowedToAct]->(c) RETURN p"
+                "query": "MATCH p=(u:User {enabled: TRUE})-[:AllowedToAct]->(c:Computer {enabled: TRUE}) RETURN p"
             }]
         },
         {
@@ -278,7 +278,7 @@
             "category": "Kerberos Delegations",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n {owned:true}) MATCH p=shortestPath((n)-[:MemberOf|HasSession|AdminTo|AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|ExecuteDCOM|AllowedToDelegate|ReadLAPSPassword|Contains|GpLink|AddAllowedToAct|AllowedToAct|SQLAdmin|ReadGMSAPassword|HasSIDHistory|CanPSRemote*1..]->(m:Computer {unconstraineddelegation: true})) WHERE NOT n=m RETURN p"
+                "query": "MATCH p=shortestPath((o {owned: TRUE})-[:MemberOf|HasSession|AdminTo|AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|ExecuteDCOM|AllowedToDelegate|ReadLAPSPassword|Contains|GpLink|AddAllowedToAct|AllowedToAct|SQLAdmin|ReadGMSAPassword|HasSIDHistory|CanPSRemote*1..]->(m:Computer {unconstraineddelegation: TRUE})) WHERE NOT o=m RETURN p"
             }]
         },
         {
@@ -402,7 +402,7 @@
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(a:Computer {enabled: TRUE})-[r:HasSession]->(b:User {enabled: TRUE}) WITH a,b,r MATCH p=shortestPath((b)-[:AdminTo|MemberOf*1..]->(a)) RETURN p",
+                "query": "MATCH p=(c:Computer {enabled: TRUE})-[:HasSession]->(u:User {enabled: TRUE}) WITH c,u MATCH p=shortestPath((u)-[:AdminTo|MemberOf*1..]->(c)) RETURN p",
                 "allowCollapse": true
             }]
         },
@@ -411,19 +411,27 @@
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(m:User {enabled: TRUE})-[r:AdminTo]->(n:Computer {enabled: TRUE}) RETURN p"
+                "query": "MATCH p=(m:User {enabled: TRUE})-[:AdminTo]->(n:Computer {enabled: TRUE}) RETURN p"
             }]
         },
         {
-            "name": "Domain admins sessions",
+            "name": "Administrators and Domain/Entreprise Admins with sessions",
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User {enabled: TRUE})-[:MemberOf]->(g:Group) WHERE g.objectid ENDS WITH '-512' MATCH p = (c:Computer {enabled: TRUE})-[:HasSession]->(n) RETURN p"
+                "query": "MATCH (u:User {enabled: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' WITH COLLECT(u.objectid) as domainAdmins MATCH p = (c2:Computer {enabled: TRUE})-[:HasSession]->(u2:User {enabled: TRUE}) WHERE u2.objectid IN domainAdmins RETURN p"
             }]
         },
         {
-            "name": "Privileged users sessions",
+            "name": "Administrators and Domain/Entreprise Admins with sessions not on domain controllers",
+            "category": "Admins",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (u:User {enabled: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' WITH COLLECT(u.objectid) as domainAdmins MATCH (c:Computer {enabled: TRUE})-[:MemberOf*1..]->(g2:Group) WHERE g2.objectid =~ '.*-(516|(?i)S-1-5-9)$' WITH COLLECT(c.objectid) as domainControllers, domainAdmins MATCH p = (c2:Computer {enabled: TRUE})-[:HasSession]->(u2:User {enabled: TRUE}) WHERE u2.objectid IN domainAdmins AND NOT c2.objectid IN domainControllers RETURN p"
+            }]
+        },
+        {
+            "name": "High Value users sessions",
             "category": "Admins",
             "queryList": [{
                 "final": true,
@@ -435,7 +443,7 @@
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u)-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ \"(?i)S-1-5-.*-525\" WITH COLLECT (u.name) as protectedUsers MATCH p=(u2:User)-[:MemberOf*1..3]->(g2:Group) WHERE u2.admincount=true AND u2.sensitive=false AND NOT u2.name IN protectedUsers RETURN p"
+                "query": "MATCH (u:User {enabled:TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '(?i)S-1-5-.*-525$' WITH COLLECT (u.objectid) as protectedUsers MATCH p=(u2:User {enabled:TRUE, admincount:TRUE, sensitive:FALSE})-[:MemberOf*1..3]->(g2:Group) WHERE NOT u2.objectid IN protectedUsers RETURN p"
             }]
         },
         {
@@ -467,7 +475,7 @@
             "category": "Groups",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(m:Group)-[r:ForceChangePassword]->(n:User) RETURN DISTINCT m[.]name,  COUNT(m[.]name) ORDER BY COUNT(m[.]name) DESC"
+                "query": "MATCH p=(m:Group)-[:ForceChangePassword]->(n:User) RETURN DISTINCT m[.]name,  COUNT(m[.]name) ORDER BY COUNT(m[.]name) DESC"
             }]
         },
         {
@@ -475,7 +483,7 @@
             "category": "Groups",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(n:User)-[r:MemberOf*1..]->(m:Group {highvalue:true}) RETURN p"
+                "query": "MATCH p=(n:User)-[:MemberOf*1..]->(m:Group {highvalue:true}) RETURN p"
             }]
         },
         {
@@ -483,7 +491,7 @@
             "category": "Groups",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(g:Group)-[r:Owns|:WriteDacl|:GenericAll|:WriteOwner|:ExecuteDCOM|:GenericWrite|:AllowedToDelegate|:ForceChangePassword]->(n:Computer) WHERE NOT g.name CONTAINS 'ADMIN' RETURN p",
+                "query": "MATCH p=(g:Group)-[:Owns|:WriteDacl|:GenericAll|:WriteOwner|:ExecuteDCOM|:GenericWrite|:AllowedToDelegate|:ForceChangePassword]->(n:Computer) WHERE NOT g.name CONTAINS 'ADMIN' RETURN p",
                 "allowCollapse": true
             }]
         },
@@ -492,25 +500,25 @@
             "category": "Groups",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c:Computer)-[r:MemberOf*1..]->(groupsWithComps:Group) WITH groupsWithComps MATCH (u:User)-[r:MemberOf*1..]->(groupsWithComps) RETURN DISTINCT(groupsWithComps) as groupsWithCompsAndUsers",
+                "query": "MATCH (c:Computer)-[:MemberOf*1..]->(groupsWithComps:Group) WITH groupsWithComps MATCH (u:User)-[r:MemberOf*1..]->(groupsWithComps) RETURN DISTINCT(groupsWithComps) as groupsWithCompsAndUsers",
                 "allowCollapse": true,
                 "endNode": "{}"
             }]
         },
         {
-            "name": "Groups that can reset passwords (Warning: Heavy)",
+            "name": "Groups that can reset passwords of enabled users (Warning: Heavy)",
             "category": "Groups",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(m:Group)-[r:ForceChangePassword]->(n:User) RETURN p"
+                "query": "MATCH p=(g:Group)-[:ForceChangePassword]->(u:User {enabled: TRUE}) RETURN p"
             }]
         },
         {
-            "name": "Groups that have local admin rights (Warning: Heavy)",
+            "name": "Groups that have local admin rights on enabled computers (Warning: Heavy)",
             "category": "Groups",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(m:Group)-[r:AdminTo]->(n:Computer) RETURN p"
+                "query": "MATCH p=(g:Group)-[:AdminTo]->(c:Computer {enabled: TRUE}) RETURN p"
             }]
         },
         {
@@ -518,31 +526,31 @@
             "category": "Users",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User) WHERE n.lastlogontimestamp=-1.0 AND n.enabled=TRUE RETURN n "
+                "query": "MATCH (u:User {enabled: TRUE, lastlogontimestamp:-1.0}) RETURN u"
             }]
         },
         {
-            "name": "Users logged in the last 90 days",
+            "name": "Users logged in the last 90 days and account still active",
             "category": "Users",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User) WHERE u.lastlogon < (datetime().epochseconds - (90 * 86400)) and NOT u.lastlogon IN [-1.0, 0.0] RETURN u"
+                "query": "MATCH (u:User {enabled: TRUE}) WHERE u.lastlogon < (datetime().epochseconds - (90 * 86400)) and NOT u.lastlogon IN [-1.0, 0.0] RETURN u"
             }]
         },
         {
-            "name": "Users with passwords last set in the last 90 days",
+            "name": "Users with passwords last set in the last 90 days and account still active",
             "category": "Users",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User) WHERE u.pwdlastset < (datetime().epochseconds - (90 * 86400)) and NOT u.pwdlastset IN [-1.0, 0.0] RETURN u"
+                "query": "MATCH (u:User {enabled: TRUE}) WHERE u.pwdlastset < (datetime().epochseconds - (90 * 86400)) and NOT u.pwdlastset IN [-1.0, 0.0] RETURN u"
             }]
         },
         {
-            "name": "Find if unprivileged users have rights to add members into groups",
+            "name": "Find if unprivileged users have rights to add members into groups (3 hops)",
             "category": "Users",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User {admincount:False}) MATCH p=allShortestPaths((n)-[r:AddMember*1..]->(m:Group)) RETURN p"
+                "query": "MATCH p=(u:User {enabled: TRUE, admincount: FALSE})-[:AddMember*1..3]->(m:Group) RETURN p"
             }]
         },
         {
@@ -586,11 +594,19 @@
             }]
         },
         {
-            "name": "Find if any domain user has interesting permissions against a GPO (Warning: Heavy)",
+            "name": "Find if any enabled unprivileged domain user has interesting permissions against a GPO (3 hops, limit 200)",
             "category": "GPOs",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(u:User)-[r:AllExtendedRights|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|GpLink*1..]->(g:GPO) RETURN p"
+                "query": "MATCH p=(u:User {enabled: TRUE, admincount: FALSE})-[:AllExtendedRights|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|GpLink*1..3]->(g:GPO) RETURN p LIMIT 200"
+            }]
+        },
+        {
+            "name": "Find if any enabled unprivileged domain user has interesting permissions against a GPO (5 hops, limit 200, Warning: Heavy)",
+            "category": "GPOs",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(u:User {enabled: TRUE, admincount: FALSE})-[:AllExtendedRights|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|GpLink*1..5]->(g:GPO) RETURN p LIMIT 200"
             }]
         },
         {
@@ -714,19 +730,19 @@
             }]
         },
         {
-            "name": "Find machines Domain Users can RDP into",
+            "name": "Find enabled machines Domain Users can RDP into",
             "category": "RDP",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(g:Group)-[:CanRDP]->(c:Computer) where g.objectid ENDS WITH '-513' RETURN p"
+                "query": "MATCH p=(g:Group)-[:CanRDP]->(c:Computer {enabled: TRUE}) where g.objectid ENDS WITH '-513' RETURN p"
             }]
         },
         {
-            "name": "Find Servers Domain Users can RDP To",
+            "name": "Find enabled Servers Domain Users can RDP To",
             "category": "RDP",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(g:Group)-[:CanRDP]->(c:Computer) where g.name STARTS WITH 'DOMAIN USERS' AND c.operatingsystem CONTAINS 'Server' RETURN p",
+                "query": "MATCH p=(g:Group)-[:CanRDP]->(c:Computer {enabled: TRUE}) WHERE g.objectid ENDS WITH '-519' AND c.operatingsystem CONTAINS 'Server' RETURN p",
                 "allowCollapse": true
             }]
         },
@@ -807,7 +823,7 @@
             "category": "Certificates",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:GPO) WHERE n.type = 'Certificate Template' RETURN n"
+                "query": "MATCH (n:GPO {type: 'Certificate Template'}) RETURN n"
             }]
         },
         {
@@ -815,7 +831,7 @@
             "category": "Certificates",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:GPO) WHERE n.type = 'Certificate Template' and n.Enabled = true RETURN n"
+                "query": "MATCH (n:GPO {Enabled: TRUE, type: 'Certificate Template'}) RETURN n"
             }]
         },
         {
@@ -823,7 +839,7 @@
             "category": "Certificates",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:GPO) WHERE n.type = 'Enrollment Service' RETURN n"
+                "query": "MATCH (n:GPO {type: 'Enrollment Service'}) RETURN n"
             }]
         },
         {
@@ -840,11 +856,11 @@
             "queryList": [{
                 "final": false,
                 "title": "Select a Certificate Template...",
-                "query": "MATCH (n:GPO) WHERE n.type = 'Certificate Template' RETURN n.name"
+                "query": "MATCH (n:GPO {type: 'Certificate Template'}) RETURN n.name"
               },
               {
                 "final": true,
-                "query": "MATCH p=(g)-[:Enroll|AutoEnroll]->(n:GPO {name:$result}) WHERE n.type = 'Certificate Template' RETURN p",
+                "query": "MATCH p=(g)-[:Enroll|AutoEnroll]->(n:GPO {type: 'Certificate Template', name:$result}) RETURN p",
                 "allowCollapse": false
             }]
         },
@@ -854,7 +870,7 @@
             "queryList": [{
                 "final": false,
                 "title": "Select a Certificate Authority...",
-                "query": "MATCH (n:GPO) WHERE n.type = 'Enrollment Service' RETURN n.name"
+                "query": "MATCH (n:GPO {type: 'Enrollment Service'}) RETURN n.name"
               },
               {
                 "final": true,
@@ -867,7 +883,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:GPO) WHERE n.type = 'Certificate Template' and n.`Enrollee Supplies Subject` = true and n.`Client Authentication` = true and n.`Enabled` = true  RETURN n"
+                "query": "MATCH (n:GPO {type: 'Certificate Template', `Enrollee Supplies Subject`: TRUE, `Client Authentication`: TRUE, `Enabled`: TRUE}) RETURN n"
             }]
         },
         {
@@ -875,7 +891,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=allShortestPaths((g {owned:true})-[*1..]->(n:GPO)) WHERE  g<>n and n.type = 'Certificate Template' and n.`Enrollee Supplies Subject` = true and n.`Client Authentication` = true and n.`Enabled` = true RETURN p"
+                "query": "MATCH p=allShortestPaths((g {owned: TRUE})-[*1..]->(n:GPO {type: 'Certificate Template', `Enrollee Supplies Subject`: TRUE, `Client Authentication`: TRUE, `Enabled`: TRUE})) WHERE g<>n RETURN p"
             }]
         },
         {
@@ -883,7 +899,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:GPO) WHERE n.type = 'Certificate Template' and n.`Enabled` = true and (n.`Extended Key Usage` = [] or 'Any Purpose' IN n.`Extended Key Usage`)  RETURN n"
+                "query": "MATCH (n:GPO {type: 'Certificate Template', `Enabled`: TRUE}) WHERE (n.`Extended Key Usage` = [] OR 'Any Purpose' IN n.`Extended Key Usage`) RETURN n"
             }]
         },
         {
@@ -891,7 +907,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=allShortestPaths((g {owned:true})-[*1..]->(n:GPO)) WHERE  g<>n and n.type = 'Certificate Template' and n.`Enabled` = true and (n.`Extended Key Usage` = [] or 'Any Purpose' IN n.`Extended Key Usage`) RETURN p"
+                "query": "MATCH p=allShortestPaths((g {owned: TRUE})-[*1..]->(n:GPO {type: 'Certificate Template', `Enabled`: TRUE})) WHERE g<>n AND (n.`Extended Key Usage` = [] OR 'Any Purpose' IN n.`Extended Key Usage`) RETURN p"
             }]
         },
         {
@@ -899,7 +915,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:GPO) WHERE n.type = 'Certificate Template' and n.`Enabled` = true and (n.`Extended Key Usage` = [] or 'Any Purpose' IN n.`Extended Key Usage` or 'Certificate Request Agent' IN n.`Extended Key Usage`)  RETURN n"
+                "query": "MATCH (n:GPO {type: 'Certificate Template', `Enabled`: TRUE}) WHERE (n.`Extended Key Usage` = [] OR 'Any Purpose' IN n.`Extended Key Usage` OR 'Certificate Request Agent' IN n.`Extended Key Usage`) RETURN n"
             }]
         },
         {
@@ -907,7 +923,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=allShortestPaths((g {owned:true})-[*1..]->(n:GPO)) WHERE  g<>n and n.type = 'Certificate Template' and n.`Enabled` = true and (n.`Extended Key Usage` = [] or 'Any Purpose' IN n.`Extended Key Usage` or 'Certificate Request Agent' IN n.`Extended Key Usage`) RETURN p"
+                "query": "MATCH p=allShortestPaths((g {owned: TRUE})-[*1..]->(n:GPO {type: 'Certificate Template', `Enabled`: TRUE})) WHERE g<>n AND (n.`Extended Key Usage` = [] OR 'Any Purpose' IN n.`Extended Key Usage` OR 'Certificate Request Agent' IN n.`Extended Key Usage`) RETURN p"
             }]
         },
         {
@@ -915,7 +931,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=shortestPath((g)-[:GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner*1..]->(n:GPO)) WHERE  g<>n and n.type = 'Certificate Template' and n.`Enabled` = true RETURN p"
+                "query": "MATCH p=shortestPath((g)-[:GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner*1..]->(n:GPO {type: 'Certificate Template', `Enabled`: TRUE})) WHERE g<>n RETURN p"
             }]
         },
         {
@@ -923,7 +939,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=allShortestPaths((g {owned:true})-[r*1..]->(n:GPO)) WHERE g<>n and n.type = 'Certificate Template' and n.Enabled = true and NONE(x in relationships(p) WHERE type(x) = 'Enroll' or type(x) = 'AutoEnroll') RETURN p"
+                "query": "MATCH p=allShortestPaths((g {owned: TRUE})-[*1..]->(n:GPO {type: 'Certificate Template', `Enabled`: TRUE})) WHERE g<>n AND NONE(x IN relationships(p) WHERE type(x) = 'Enroll' OR type(x) = 'AutoEnroll') RETURN p"
             }]
         },
         {
@@ -931,7 +947,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:GPO) WHERE n.type = 'Enrollment Service' and n.`User Specified SAN` = 'Enabled' RETURN n"
+                "query": "MATCH (n:GPO {type: 'Enrollment Service', `User Specified SAN`:'Enabled'}) RETURN n"
             }]
         },
         {
@@ -939,7 +955,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=shortestPath((g)-[r:GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|ManageCa|ManageCertificates*1..]->(n:GPO)) WHERE  g<>n and n.type = 'Enrollment Service' RETURN p"
+                "query": "MATCH p=shortestPath((g)-[:GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|ManageCa|ManageCertificates*1..]->(n:GPO {type: 'Enrollment Service'})) WHERE g<>n RETURN p"
             }]
         },
         {
@@ -947,7 +963,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=allShortestPaths((g {owned:true})-[*1..]->(n:GPO)) WHERE  g<>n and n.type = 'Enrollment Service' and NONE(x in relationships(p) WHERE type(x) = 'Enroll' or type(x) = 'AutoEnroll') RETURN p"
+                "query": "MATCH p=allShortestPaths((g {owned: TRUE})-[*1..]->(n:GPO {type:'Enrollment Service'})) WHERE g<>n AND NONE(x in relationships(p) WHERE type(x) = 'Enroll' OR type(x) = 'AutoEnroll') RETURN p"
             }]
         },
         {
@@ -955,7 +971,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:GPO) WHERE n.type = 'Enrollment Service' and n.`Web Enrollment` = 'Enabled' RETURN n"
+                "query": "MATCH (n:GPO {type: 'Enrollment Service', `Web Enrollment`:'Enabled'}) RETURN n"
             }]
         },
         {
@@ -964,7 +980,7 @@
             "queryList": [
                 {
                 "final": true,
-                "query": "MATCH (n:GPO) WHERE n.type = 'Certificate Template' and n.`Enrollee Supplies Subject` = true and n.`Client Authentication` = true and n.`Enabled` = true  RETURN n"
+                "query": "MATCH (n:GPO {type: 'Certificate Template', `Enrollee Supplies Subject`: TRUE, `Client Authentication`: TRUE, `Enabled`: TRUE}) RETURN n"
                 }
             ]
         },
@@ -974,7 +990,7 @@
             "queryList": [
                 {
                 "final": true,
-                "query": "MATCH (n:GPO) WHERE n.type = 'Certificate Template' and 'NoSecurityExtension' in n.`Enrollment Flag` and n.`Enabled` = true  RETURN n"
+                "query": "MATCH (n:GPO {type: 'Certificate Template', `Enabled`: TRUE}) WHERE 'NoSecurityExtension' IN n.`Enrollment Flag` RETURN n"
                 }
             ]
         },
@@ -984,105 +1000,105 @@
             "queryList": [
                 {
                 "final": true,
-                "query": "MATCH p=allShortestPaths((g {owned:true})-[r*1..]->(n:GPO)) WHERE n.type = 'Certificate Template' and g<>n and 'NoSecurityExtension' in n.`Enrollment Flag` and n.`Enabled` = true and NONE(rel in r WHERE type(rel) in ['EnabledBy','Read','ManageCa','ManageCertificates']) RETURN p"
+                "query": "MATCH p=allShortestPaths((g {owned: TRUE})-[r*1..]->(n:GPO {type: 'Certificate Template', `Enabled`: TRUE})) WHERE g<>n AND 'NoSecurityExtension' IN n.`Enrollment Flag` AND NONE(rel IN r WHERE type(rel) IN ['EnabledBy','Read','ManageCa','ManageCertificates']) RETURN p"
                 }
             ]
         },
         {
-			"name": "Find users with a plaintext attribute that can RDP into something",
+			"name": "Find enabled users with a plaintext attribute that can RDP into something",
 			"category": "PlainText Password Queries",
 			"queryList": [
 				{
 					"final": true,
-					"query": "MATCH (u1:User) WHERE u1.plaintext=True MATCH p1=(u1)-[:CanRDP*1..]->(c:Computer) RETURN u1",
+					"query": "MATCH p=(u:User {enabled: TRUE, plaintext: TRUE})-[:CanRDP*1..]->(c:Computer) RETURN u",
 					"allowCollapse": true
 				}
 			]
 		},
 		{
-			"name": "Find users with a plaintext attribute that belong to high value groups",
+			"name": "Find enabled users with a plaintext attribute that belong to high value groups",
 			"category": "PlainText Password Queries",
 			"queryList": [
 				{
 					"final": true,
-					"query": "MATCH (u1:User) WHERE u1.plaintext=True MATCH p=(u1:User)-[r:MemberOf*1..]->(m:Group {highvalue:true}) RETURN u1",
+					"query": "MATCH p=(u:User {enabled, TRUE, plaintext: TRUE})-[:MemberOf*1..]->(g:Group {highvalue: TRUE}) RETURN p",
 					"allowCollapse": true
 				}
 			]
 		},
 		{
-			"name": "Find users with a plaintext attribute that are kerberoastable",
+			"name": "Find enabled users with a plaintext attribute that are kerberoastable",
 			"category": "PlainText Password Queries",
 			"queryList": [
 				{
 					"final": true,
-					"query": "MATCH (u1:User) WHERE u1.plaintext=True AND u1.hasspn=True RETURN u1",
+					"query": "MATCH (u:User {enabled: TRUE, plaintext: TRUE, hasspn: TRUE}) RETURN u",
 					"allowCollapse": true
 				}
 			]
 		},
 		{
-			"name": "Return users with seasons in their password and are high value targets",
+			"name": "Find enabled users with seasons in their password and are high value targets",
 			"category": "PlainText Password Queries",
 			"queryList": [
 				{
 					"final": true,
-					"query": "MATCH (u1:User) WHERE u1.plaintextpassword =~ \"([Ww]inter.*|[sS]pring.*|[sS]ummer.*|[fF]all.*)\" MATCH p=(u1:User)-[r:MemberOf*1..]->(m:Group {highvalue:true}) RETURN u1",
+					"query": "MATCH p=(u:User {enabled: TRUE, plaintext: TRUE})-[:MemberOf*1..]->(g:Group {highvalue: TRUE}) WHERE u.plaintextpassword =~ '(?i).*(?:winter|spring|summer|fall).*' RETURN u",
 					"allowCollapse": true
 				}
 			]
 		},
 		{
-			"name": "Return users with seasons in their password and have local admin on at least one computer",
+			"name": "Find enabled users with seasons in their password and have local admin on at least one computer",
 			"category": "PlainText Password Queries",
 			"queryList": [
 				{
 					"final": true,
-					"query": "MATCH (u1:User) WHERE u1.plaintextpassword =~ \"([Ww]inter.*|[sS]pring.*|[sS]ummer.*|[fF]all.*)\" MATCH p=(u1:User)-[r:AdminTo]->(n:Computer) RETURN p",
+					"query": "MATCH p=(u:User {enabled: TRUE, plaintext: TRUE})-[:AdminTo]->(n:Computer) WHERE u.plaintextpassword =~ '(?i).*(?:winter|spring|summer|fall).*' RETURN p",
 					"allowCollapse": true
 				}
 			]
 		},
 		{
-			"name": "Return users with seasons in their password and a path to high value targets (limit to 25 results)",
+			"name": "Find enabled users with seasons in their password and a path to high value targets (limit to 25 results)",
 			"category": "PlainText Password Queries",
 			"queryList": [
 				{
 					"final": true,
-					"query": "MATCH (u1:User) WHERE u1.plaintextpassword =~ \"([Ww]inter.*|[sS]pring.*|[sS]ummer.*|[fF]all.*)\" MATCH p=shortestPath((u1:User)-[*1..]->(n {highvalue:true})) WHERE u1<>n RETURN u1 LIMIT 25",
+					"query": "MATCH p=shortestPath((u:User {enabled: TRUE, plaintext: TRUE})-[*1..]->(n {highvalue: TRUE})) WHERE u.plaintextpassword =~ '(?i).*(?:winter|spring|summer|fall).*' AND u<>n RETURN u LIMIT 25",
 					"allowCollapse": true
 				}
 			]
 		},
 		{
-			"name": "Return users with a variant of \"password\" in their password and are high value targets",
+			"name": "Find enabled users with a variant of \"password\" in their password and are members of high value groups",
 			"category": "PlainText Password Queries",
 			"queryList": [
 				{
 					"final": true,
-					"query": "MATCH (u1:User) WHERE u1.plaintextpassword =~ \"(.*[pP][aA@][sS$][sS$][wW][oO0][rR][dD].*)\" MATCH p=(u1:User)-[r:MemberOf*1..]->(m:Group {highvalue:true}) RETURN u1",
+					"query": "MATCH p=(u:User {enabled: TRUE, plaintext: TRUE})-[:MemberOf*1..]->(m:Group {highvalue: TRUE}) WHERE u.plaintextpassword =~ '(?i).*(?:password).*' RETURN u",
 					"allowCollapse": true
 				}
 			]
 		},
 		{
-			"name": "Return users with a variant of \"password\" in their password and have local admin on at least one computer",
+			"name": "Find enabled users with a variant of \"password\" in their password and have local admin on at least one computer",
 			"category": "PlainText Password Queries",
 			"queryList": [
 				{
 					"final": true,
-					"query": "MATCH (u1:User) WHERE u1.plaintextpassword =~ \"(.*[pP][aA@][sS$][sS$][wW][oO0][rR][dD].*)\" MATCH p=(u1:User)-[r:AdminTo]->(n:Computer) RETURN p",
+					"query": "MATCH p=(u:User {enabled: TRUE, plaintext: TRUE})-[:AdminTo]->(c:Computer {enabled: TRUE}) WHERE u.plaintextpassword =~ '(?i).*(?:password).*' RETURN u",
 					"allowCollapse": true
 				}
 			]
 		},
 		{
-			"name": "Return users with a variant of \"password\" in their password and a path to high value targets (limit to 25 results)",
+			"name": "Find enabled users with a variant of \"password\" in their password and a path to high value targets (limit to 25 results)",
 			"category": "PlainText Password Queries",
 			"queryList": [
 				{
 					"final": true,
-					"query": "MATCH (u1:User) WHERE u1.plaintextpassword =~ \"(.*[pP][aA@][sS$][sS$][wW][oO0][rR][dD].*)\"  MATCH p=shortestPath((u1:User)-[*1..]->(n {highvalue:true})) WHERE  u1<>n RETURN u1 LIMIT 25",
+					"query": "MATCH p=shortestPath((u:User {enabled: TRUE, plaintext: TRUE})-[*1..]->(o {highvalue: TRUE})) WHERE u.plaintextpassword =~ '(?i).*(?:password).*' RETURN p LIMIT 25",
 					"allowCollapse": true
 				}
 			]
@@ -1157,6 +1173,11 @@
                 },
                 {
                     "final": false,
+                    "title": "Add index on the property User Plaintext",
+                    "query": "CREATE INDEX UserPlaintextIdx IF NOT EXISTS FOR (u:User) on (u.plaintext)"
+                },
+                {
+                    "final": false,
                     "title": "Add index on the property Computer Enabled",
                     "query": "CREATE INDEX ComputerEnabledIdx IF NOT EXISTS FOR (c:Computer) on (c.enabled)"
                 },
@@ -1164,6 +1185,16 @@
                     "final": false,
                     "title": "Add index on the property User Enabled",
                     "query": "CREATE INDEX UserEnabledIdx IF NOT EXISTS FOR (u:User) on (u.enabled)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property User HasSPN",
+                    "query": "CREATE INDEX UserHasSPNIdx IF NOT EXISTS FOR (u:User) on (u.hasspn)"
+                },
+                {
+                    "final": false,
+                    "title": "Add index on the property GPO Type",
+                    "query": "CREATE INDEX GPOTypeIdx IF NOT EXISTS FOR (g:GPO) on (g.type)"
                 },
                 {
                     "final": true,


### PR DESCRIPTION
This PR aims at improving the custom queries for Bloodhound.

To do so, I refactored many queries to:
- standardize a bit more the formatting while reducing the queries length
- improve the performance of queries by adding more criteria to reduce the set of nodes Neo4j must take into account when computing the results, the flag `enabled` is a typical example
- remove useless subqueries
- improve the regexp for the queries checking for plaintext password
- fix a bogus request
- one query was not doing what the comment said it would
- add more indexes
- add one nice query I wrote: Administrators and Domain/Entreprise Admins with sessions not on domain controllers