### PR TITLE
Bloodhound customqueries: better RDP queries

### DIFF
--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -163,7 +163,7 @@
               },
               {
                 "final": true,
-                "query": "WITH split($result, \"=>\") as selectedDomains WITH selectedDomains[0] as sourceDomain, selectedDomains[1] as destDomain MATCH (n:User {domain: sourceDomain}) MATCH (m:Computer {domain: destDomain}) MATCH p=allShortestPaths((n)-[r:MemberOf|HasSession|AdminTo|AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|CanRDP|ExecuteDCOM|AllowedToDelegate|ReadLAPSPassword|Contains|GpLink|AddAllowedToAct|AllowedToAct|SQLAdmin*1..]->(m)) WHERE NOT n = m RETURN p",
+                "query": "WITH split($result, \"=>\") AS selectedDomains WITH selectedDomains[0] AS sourceDomain, selectedDomains[1] AS destDomain MATCH (n:User {domain: sourceDomain}) MATCH (m:Computer {domain: destDomain}) MATCH p=allShortestPaths((n)-[r:MemberOf|HasSession|AdminTo|AllExtendedRights|AddMember|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner|CanRDP|ExecuteDCOM|AllowedToDelegate|ReadLAPSPassword|Contains|GpLink|AddAllowedToAct|AllowedToAct|SQLAdmin*1..]->(m)) WHERE NOT n = m RETURN p",
                 "startNode": "{}",
                 "allowCollapse": false
             }]
@@ -419,7 +419,7 @@
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User {enabled: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' WITH COLLECT(u.objectid) as domainAdmins MATCH p = (c2:Computer {enabled: TRUE})-[:HasSession]->(u2:User {enabled: TRUE}) WHERE u2.objectid IN domainAdmins RETURN p"
+                "query": "MATCH (u:User {enabled: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' WITH COLLECT(u.objectid) AS domainAdmins MATCH p = (c2:Computer {enabled: TRUE})-[:HasSession]->(u2:User {enabled: TRUE}) WHERE u2.objectid IN domainAdmins RETURN p"
             }]
         },
         {
@@ -427,7 +427,7 @@
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User {enabled: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' WITH COLLECT(u.objectid) as domainAdmins MATCH (c:Computer {enabled: TRUE})-[:MemberOf*1..]->(g2:Group) WHERE g2.objectid =~ '.*-(516|(?i)S-1-5-9)$' WITH COLLECT(c.objectid) as domainControllers, domainAdmins MATCH p = (c2:Computer {enabled: TRUE})-[:HasSession]->(u2:User {enabled: TRUE}) WHERE u2.objectid IN domainAdmins AND NOT c2.objectid IN domainControllers RETURN p"
+                "query": "MATCH (u:User {enabled: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' WITH COLLECT(u.objectid) AS domainAdmins MATCH (c:Computer {enabled: TRUE})-[:MemberOf*1..]->(g2:Group) WHERE g2.objectid =~ '.*-(516|(?i)S-1-5-9)$' WITH COLLECT(c.objectid) AS domainControllers, domainAdmins MATCH p = (c2:Computer {enabled: TRUE})-[:HasSession]->(u2:User {enabled: TRUE}) WHERE u2.objectid IN domainAdmins AND NOT c2.objectid IN domainControllers RETURN p"
             }]
         },
         {
@@ -443,7 +443,7 @@
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User {enabled:TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '(?i)S-1-5-.*-525$' WITH COLLECT (u.objectid) as protectedUsers MATCH p=(u2:User {enabled:TRUE, admincount:TRUE, sensitive:FALSE})-[:MemberOf*1..3]->(g2:Group) WHERE NOT u2.objectid IN protectedUsers RETURN p"
+                "query": "MATCH (u:User {enabled:TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '(?i)S-1-5-.*-525$' WITH COLLECT (u.objectid) AS protectedUsers MATCH p=(u2:User {enabled:TRUE, admincount:TRUE, sensitive:FALSE})-[:MemberOf*1..3]->(g2:Group) WHERE NOT u2.objectid IN protectedUsers RETURN p"
             }]
         },
         {
@@ -451,7 +451,7 @@
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User {enabled: TRUE, admincount: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-525$' WITH COLLECT(u.objectid) as protectedUsers MATCH p=(u2:User {enabled: TRUE, admincount: TRUE, sensitive: FALSE})-[:MemberOf*1..]->(g2:Group) WHERE NOT u2.objectid IN protectedUsers AND g2.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' RETURN p"
+                "query": "MATCH (u:User {enabled: TRUE, admincount: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-525$' WITH COLLECT(u.objectid) AS protectedUsers MATCH p=(u2:User {enabled: TRUE, admincount: TRUE, sensitive: FALSE})-[:MemberOf*1..]->(g2:Group) WHERE NOT u2.objectid IN protectedUsers AND g2.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' RETURN p"
             }]
         },
         {
@@ -459,7 +459,7 @@
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User {enabled: TRUE, admincount: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-525$' WITH COLLECT (u.objectid) as protectedUsers MATCH p=(u2:User {enabled: TRUE, sensitive: FALSE})-[:MemberOf*1..]->(g2:Group {highvalue: TRUE}) WHERE NOT u2.objectid IN protectedUsers RETURN p"
+                "query": "MATCH (u:User {enabled: TRUE, admincount: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-525$' WITH COLLECT (u.objectid) AS protectedUsers MATCH p=(u2:User {enabled: TRUE, sensitive: FALSE})-[:MemberOf*1..]->(g2:Group {highvalue: TRUE}) WHERE NOT u2.objectid IN protectedUsers RETURN p"
             }]
         },
         {
@@ -500,7 +500,7 @@
             "category": "Groups",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c:Computer)-[:MemberOf*1..]->(groupsWithComps:Group) WITH groupsWithComps MATCH (u:User)-[r:MemberOf*1..]->(groupsWithComps) RETURN DISTINCT(groupsWithComps) as groupsWithCompsAndUsers",
+                "query": "MATCH (c:Computer)-[:MemberOf*1..]->(groupsWithComps:Group) WITH groupsWithComps MATCH (u:User)-[r:MemberOf*1..]->(groupsWithComps) RETURN DISTINCT(groupsWithComps) AS groupsWithCompsAndUsers",
                 "allowCollapse": true,
                 "endNode": "{}"
             }]
@@ -662,7 +662,7 @@
             "category": "Top Ten",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User),(m:Computer), (n)<-[r:HasSession]-(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH n, count(r) as rel_count order by rel_count desc LIMIT 10 MATCH p=(m)-[r:HasSession]->(n) RETURN p",
+                "query": "MATCH (n:User),(m:Computer), (n)<-[r:HasSession]-(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH n, count(r) AS rel_count order by rel_count desc LIMIT 10 MATCH p=(m)-[r:HasSession]->(n) RETURN p",
                 "allowCollapse": true
             }]
         },
@@ -671,7 +671,7 @@
             "category": "Top Ten",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User),(m:Computer), (n)<-[r:HasSession]-(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) as rel_count order by rel_count desc LIMIT 10 MATCH p=(m)-[r:HasSession]->(n) RETURN p",
+                "query": "MATCH (n:User),(m:Computer), (n)<-[r:HasSession]-(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) AS rel_count order by rel_count desc LIMIT 10 MATCH p=(m)-[r:HasSession]->(n) RETURN p",
                 "allowCollapse": true
             }]
         },
@@ -680,7 +680,7 @@
             "category": "Top Ten",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH n, count(r) as rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) RETURN p",
+                "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH n, count(r) AS rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) RETURN p",
                 "allowCollapse": true
             }]
         },
@@ -689,7 +689,7 @@
             "category": "Top Ten",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) as rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) RETURN p",
+                "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) AS rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) RETURN p",
                 "allowCollapse": true
             }]
         },
@@ -698,7 +698,7 @@
             "category": "Top Ten",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) as rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) RETURN m",
+                "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) AS rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) RETURN m",
                 "allowCollapse": true
             }]
         },
@@ -707,7 +707,7 @@
             "category": "Top Ten",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) as rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) SET m.highvalue = true RETURN m",
+                "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) AS rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) SET m.highvalue = true RETURN m",
                 "allowCollapse": true
             }]
         },
@@ -981,7 +981,7 @@
             "category": "AD CS Domain Escalation",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=allShortestPaths((g {owned: TRUE})-[*1..]->(n:GPO {type:'Enrollment Service'})) WHERE g<>n AND NONE(x in relationships(p) WHERE type(x) = 'Enroll' OR type(x) = 'AutoEnroll') RETURN p"
+                "query": "MATCH p=allShortestPaths((g {owned: TRUE})-[*1..]->(n:GPO {type:'Enrollment Service'})) WHERE g<>n AND NONE(x IN relationships(p) WHERE type(x) = 'Enroll' OR type(x) = 'AutoEnroll') RETURN p"
             }]
         },
         {

--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -202,7 +202,7 @@
             }]
         },
         {
-            "name": " Kerberoastable enabled users and where they are AdminTo",
+            "name": "Kerberoastable enabled users and where they are AdminTo",
             "category": "Roasting",
             "queryList": [{
                 "final": true,
@@ -730,19 +730,37 @@
             }]
         },
         {
-            "name": "Find enabled machines Domain Users can RDP into",
+            "name": "Find enabled machines Domain Users can RDP to",
             "category": "RDP",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(g:Group)-[:CanRDP]->(c:Computer {enabled: TRUE}) where g.objectid ENDS WITH '-513' RETURN p"
+                "query": "MATCH p=((g:Group)-[:CanRDP]->(c:Computer {enabled: TRUE})) WHERE g.objectid ENDS WITH '-513' RETURN p AS path UNION MATCH p2=((g2:Group)-[:MemberOf*1..]->(g3:Group)-[:CanRDP]->(c2:Computer {enabled: TRUE})) WHERE g2.objectid ENDS WITH '-513' RETURN p2 AS path"
             }]
         },
         {
-            "name": "Find enabled Servers Domain Users can RDP To",
+            "name": "Find enabled servers Domain Users can RDP to",
             "category": "RDP",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(g:Group)-[:CanRDP]->(c:Computer {enabled: TRUE}) WHERE g.objectid ENDS WITH '-519' AND c.operatingsystem CONTAINS 'Server' RETURN p",
+                "query": "MATCH p=((g:Group)-[:CanRDP]->(c:Computer {enabled: TRUE})) WHERE g.objectid ENDS WITH '-513' AND c.operatingsystem =~ '(?i).*Server.*' RETURN p AS path UNION MATCH p2=((g2:Group)-[:MemberOf*1..]->(g3:Group)-[:CanRDP]->(c2:Computer {enabled: TRUE})) WHERE g2.objectid ENDS WITH '-513' AND c2.operatingsystem =~ '(?i).*Server.*' RETURN p2 AS path",
+                "allowCollapse": true
+            }]
+        },
+        {
+            "name": "Find enabled machines Authenticated Users can RDP to",
+            "category": "RDP",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=((g:Group)-[:CanRDP]->(c:Computer {enabled: TRUE})) WHERE g.objectid =~ '(?i).*S-1-5-11$' RETURN p AS path UNION MATCH p2=((g2:Group)-[:MemberOf*1..]->(g3:Group)-[:CanRDP]->(c2:Computer {enabled: TRUE})) WHERE g2.objectid =~ '(?i).*S-1-5-11$' RETURN p2 AS path",
+                "allowCollapse": true
+            }]
+        },
+        {
+            "name": "Find enabled servers Authenticated Users can RDP to",
+            "category": "RDP",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=((g:Group)-[:CanRDP]->(c:Computer {enabled: TRUE})) WHERE g.objectid =~ '(?i).*S-1-5-11$' AND c.operatingsystem =~ '(?i).*Server.*' RETURN p AS path UNION MATCH p2=((g2:Group)-[:MemberOf*1..]->(g3:Group)-[:CanRDP]->(c2:Computer {enabled: TRUE})) WHERE g2.objectid =~ '(?i).*S-1-5-11$' AND c2.operatingsystem =~ '(?i).*Server.*' RETURN p2 AS path",
                 "allowCollapse": true
             }]
         },


### PR DESCRIPTION
Dear team,

I noticed that when querying Bloodhound to get a list of machines where Domain users can RDP to, it only lists the machines where the single node "domain users" has a _direct_ canRDP relationtype with the computer objects.

The existing query does not take into account that Domain Users can be member of a group, and it's this group that has a canRDP relationship with the computers.

This PR fixes that, and is basically the union of the builtin queries: `First Degree RDP Privileges` and `Group Delegated RDP Privileges`.

In addition:
- I added new queries to return paths from authenticated users->RDP->computers, with a distinction machines != servers.
- the case of some keywords were switched to uppercase for clarity.