### PR TITLE
Tool ysoserialnet

### DIFF
--- a/sources/assets/shells/aliases.d/ysoserialnet
+++ b/sources/assets/shells/aliases.d/ysoserialnet
@@ -1,0 +1,1 @@
+alias ysoserialnet='wine /opt/tools/ysoserialnet/ysoserial.exe'

--- a/sources/assets/shells/history.d/ysoserialnet
+++ b/sources/assets/shells/history.d/ysoserialnet
@@ -1,0 +1,1 @@
+ysoserialnet -f Json.Net -g ObjectDataProvider -o raw -c "calc" -t

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -915,6 +915,7 @@ function package_web() {
     install_git-dumper              # Dump a git repository from a website
     install_gittools                # Dump a git repository from a website
     install_ysoserial               # Deserialization payloads
+    install_ysoserialnet            # Deserialization .NET payloads
     install_phpggc                  # php deserialization payloads
     install_symfony-exploits        # symfony secret fragments exploit
     install_jdwp_shellifier         # exploit java debug

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -569,6 +569,25 @@ function install_phpggc() {
     add-to-list "phpggc,https://github.com/ambionics/phpggc,Exploit generation tool for the PHP platform."
 }
 
+function install_ysoserialnet() {
+    colorecho "Installing ysoserialnet"
+    # Source: https://github.com/pwntester/ysoserial.net/issues/9#issuecomment-790819759
+    mkdir /opt/tools/ysoserialnet/
+    dpkg --add-architecture i386
+    apt update
+    fapt mono-complete wine winetricks wine32:i386
+    wget https://github.com/pwntester/ysoserial.net/releases/download/v1.36/ysoserial-1dba9c4416ba6e79b6b262b758fa75e2ee9008e9.zip -O /opt/tools/ysoserialnet/ysoserialnet.zip
+    unzip -o /opt/tools/ysoserialnet/ysoserialnet.zip -d /opt/tools/ysoserialnet/
+    mv /opt/tools/ysoserialnet/Release/* /opt/tools/ysoserialnet/
+    rm -rf /opt/tools/ysoserialnet/Release/
+    rm /opt/tools/ysoserialnet/ysoserialnet.zip
+    winetricks -q dotnet48
+    add-aliases ysoserialnet
+    add-history ysoserialnet
+    add-test-command "ysoserialnet -h"
+    add-to-list "ysoserialnet,https://github.com/pwntester/ysoserial.net,ysoserial.net is a collection of utilities and property-oriented programming gadget chains discovered in common .NET libraries that can, under the right conditions, exploit .NET applications performing unsafe deserialization of objects."
+}
+
 function install_symfony-exploits(){
     colorecho "Installing symfony-exploits"
     git -C /opt/tools clone --depth 1 https://github.com/ambionics/symfony-exploits


### PR DESCRIPTION
# Description

This PR aims to provide a new tool called Ysoserial.NET (https://github.com/pwntester/ysoserial.net), this tool is similar to `ysoserial` but for generating .NET payload. This was made in order to avoid spawning a Windows VM just to use this tool.

Install instructions come from: https://github.com/pwntester/ysoserial.net/issues/9#issuecomment-790819759 so thanks to this user.

# Related issues

N / A

# Point of attention

The tool use `wine` as it is a Windows compiled EXE and also the i386 architecture need to be added for Wine to function properly.
