### PR TITLE
Reduce image size by adding flag depth 1 when git cloning

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -120,9 +120,8 @@ function install_bloodhound-py() {
 function install_bloodhound-ce-py() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing and Python ingestor for BloodHound-CE"
-    git -C /opt/tools/ clone https://github.com/dirkjanm/BloodHound.py BloodHound-CE.py
+    git -C /opt/tools/ clone --branch bloodhound-ce --depth 1 https://github.com/dirkjanm/BloodHound.py BloodHound-CE.py
     cd /opt/tools/BloodHound-CE.py || exit
-    git checkout bloodhound-ce
     python3 -m venv --system-site-packages ./venv
     source ./venv/bin/activate
     pip3 install .

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -259,7 +259,7 @@ function install_neovim() {
     then
         # Build take ~5min
         fapt gettext
-        git clone https://github.com/neovim/neovim.git
+        git clone --depth 1 https://github.com/neovim/neovim.git
         cd neovim || exit
         make CMAKE_BUILD_TYPE=RelWithDebInfo
         make install

--- a/sources/install/package_c2.sh
+++ b/sources/install/package_c2.sh
@@ -62,10 +62,6 @@ function install_routersploit() {
 function install_sliver() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing Sliver"
-    # Deletion of --depth 1 due to installation of stable branch
-    git -C /opt/tools/ clone https://github.com/BishopFox/sliver.git
-    cd /opt/tools/sliver || exit
-    asdf local golang 1.19
     # making the static version checkout a temporary thing
     # function below will serve as a reminder to update sliver's version regularly
     # when the pipeline fails because the time limit is reached: update the version and the time limit
@@ -74,8 +70,11 @@ function install_sliver() {
     if [[ "$(date +%Y%m%d)" -gt "$(date -d $temp_fix_limit +%Y%m%d)" ]]; then
       criticalecho "Temp fix expired. Exiting."
     else
-      git checkout tags/v1.5.41
+      # Add branch v1.5.41 due to installation of stable branch
+      git -C /opt/tools/ clone --branch v1.5.41 --depth 1 https://github.com/BishopFox/sliver.git
+      cd /opt/tools/sliver || exit
     fi
+    asdf local golang 1.19
     make
     ln -s /opt/tools/sliver/sliver-server /opt/tools/bin/sliver-server
     ln -s /opt/tools/sliver/sliver-client /opt/tools/bin/sliver-client

--- a/sources/install/package_cracking.sh
+++ b/sources/install/package_cracking.sh
@@ -69,7 +69,7 @@ function install_geowordlists() {
 function install_pkcrack() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing pkcrack"
-    git -C /opt/tools/ clone https://github.com/keyunluo/pkcrack
+    git -C /opt/tools/ clone --depth 1 https://github.com/keyunluo/pkcrack
     mkdir -v /opt/tools/pkcrack/build/
     cd /opt/tools/pkcrack/build || exit
     cmake ..

--- a/sources/install/package_desktop.sh
+++ b/sources/install/package_desktop.sh
@@ -35,8 +35,7 @@ function install_xfce() {
 
     # Dock
     fapt xfce4-dev-tools libglib2.0-dev libgtk-3-dev libwnck-3-dev libxfce4ui-2-dev libxfce4panel-2.0-dev g++ build-essential
-    git -C /tmp clone --depth 1 https://gitlab.xfce.org/panel-plugins/xfce4-docklike-plugin.git
-    git -C /tmp/xfce4-docklike-plugin checkout xfce4-docklike-plugin-0.4.2
+    git -C /tmp clone --branch xfce4-docklike-plugin-0.4.2 --depth 1 https://gitlab.xfce.org/panel-plugins/xfce4-docklike-plugin.git
     cd /tmp/xfce4-docklike-plugin
     sh autogen.sh --prefix=/tmp/
     make

--- a/sources/install/package_desktop.sh
+++ b/sources/install/package_desktop.sh
@@ -35,7 +35,7 @@ function install_xfce() {
 
     # Dock
     fapt xfce4-dev-tools libglib2.0-dev libgtk-3-dev libwnck-3-dev libxfce4ui-2-dev libxfce4panel-2.0-dev g++ build-essential
-    git -C /tmp clone https://gitlab.xfce.org/panel-plugins/xfce4-docklike-plugin.git
+    git -C /tmp clone --depth 1 https://gitlab.xfce.org/panel-plugins/xfce4-docklike-plugin.git
     git -C /tmp/xfce4-docklike-plugin checkout xfce4-docklike-plugin-0.4.2
     cd /tmp/xfce4-docklike-plugin
     sh autogen.sh --prefix=/tmp/

--- a/sources/install/package_mobile.sh
+++ b/sources/install/package_mobile.sh
@@ -31,7 +31,7 @@ function install_scrpy() {
                  meson ninja-build libsdl2-dev \
                  libavcodec-dev libavdevice-dev libavformat-dev libavutil-dev \
                  libswresample-dev libusb-1.0-0 libusb-1.0-0-dev
-    git clone https://github.com/Genymobile/scrcpy
+    git clone --depth 1 https://github.com/Genymobile/scrcpy
     # opening subshell to not have to cd back
     (
       cd scrcpy || exit

--- a/sources/install/package_wifi.sh
+++ b/sources/install/package_wifi.sh
@@ -6,19 +6,19 @@ source common.sh
 function install_wifi_apt_tools() {
     colorecho "Installing wifi apt tools"
     fapt aircrack-ng reaver bully cowpatty
-  
+
     add-aliases aircrack-ng
 
     add-history aircrack-ng
     add-history reaver
     add-history bully
     add-history cowpatty
-  
+
     add-test-command "aircrack-ng --help"                                                # WiFi security auditing tools suite
     add-test-command "reaver --help; reaver --help |& grep 'Tactical Network Solutions'" # Brute force attack against Wifi Protected Setup
     add-test-command "bully --version"                                                   # WPS brute force attack
     add-test-command "cowpatty -V"                                                       # WPA2-PSK Cracking
-  
+
     add-to-list "aircrack-ng,https://www.aircrack-ng.org,A suite of tools for wireless penetration testing"
     add-to-list "reaver,https://github.com/t6x/reaver-wps-fork-t6x,reaver is a tool for brute-forcing WPS (Wireless Protected Setup) PINs."
     add-to-list "bully,https://github.com/aanarchyy/bully,bully is a tool for brute-forcing WPS (Wireless Protected Setup) PINs."


### PR DESCRIPTION
I noticed that some tools missed the flag `--depth 1` for `git clone`.

For some tools, it was simply forgotten.

For others, the flag --depth 1 was removed for temp fixes reasons.
This PR reinstates the depth flag to clone directly the appropriate branch in a single command instead of doing a `git clone` followed by a `git checkout`:

- Example with sliver: `git -C /opt/tools/ clone --branch v1.5.41 --depth 1 https://github.com/BishopFox/sliver.git`

- Another with Bloodhound-CE: `git -C /opt/tools/ clone --branch bloodhound-ce --depth 1 https://github.com/dirkjanm/BloodHound.py BloodHound-CE.py`

About sliver, I moved the temp fix criticalecho at the beginning of the function to only clone the repo if the date condition is met. I hope it's ok like this.