### PR TITLE
Reduce image size by removing sslscan build files

### DIFF
--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -840,7 +840,8 @@ function install_sslscan() {
     git -C /opt/tools clone --depth 1 https://github.com/rbsec/sslscan.git
     cd /opt/tools/sslscan || exit
     make static
-    ln -s /opt/tools/sslscan/sslscan /opt/tools/bin/sslscan
+    mv /opt/tools/sslscan/sslscan /opt/tools/bin/sslscan
+    make clean
     add-history sslscan
     add-test-command "sslscan --version"
     add-to-list "sslscan,https://github.com/rbsec/sslscan,a tool for testing SSL/TLS encryption on servers"


### PR DESCRIPTION
Hello,

sslscan is built statically, so there is no need to keep in the image the files generated when building it.

Before the PR:
```
du -hs /opt/tools/* | grep sslscan
220M	/opt/tools/sslscan
```

After the PR:
```
du -hs /opt/tools/* | grep sslscan
980K	/opt/tools/sslscan
```