### PR TITLE
Remove commas from descriptions + fix pipeline

### DIFF
--- a/.github/workflows/sub_export_tools.yml
+++ b/.github/workflows/sub_export_tools.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           grep -qE '([^,]*,[^,]*){3,}' installed_tools.csv \
             && (echo '[-] Wrong number of columns on the following lines' \
-            && grep -oE '([^,]*,[^,]*){3,}' installed_tools.csv || exit 1) \
+            && grep -oE '([^,]*,[^,]*){3,}' installed_tools.csv) && exit 1 \
             || (echo '[+] List contains right number of columns' && exit 0)
       - name: Stop the container
         if: always() && steps.image_exists.outcome == 'success'

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1346,7 +1346,7 @@ function install_sccmhunter() {
     add-aliases sccmhunter
     add-history sccmhunter
     add-test-command "sccmhunter.py --help"
-    add-to-list "sccmhunter,https://github.com/garrettfoster13/sccmhunter,SCCMHunter is a post-ex tool built to streamline identifying, profiling, and attacking SCCM related assets in an Active Directory domain."
+    add-to-list "sccmhunter,https://github.com/garrettfoster13/sccmhunter,SCCMHunter is a post-ex tool built to streamline identifying profiling and attacking SCCM related assets in an Active Directory domain."
 }
 
 function install_sccmwtf() {

--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -182,7 +182,7 @@ function install_creds() {
     pipx install --system-site-packages git+https://github.com/ihebski/DefaultCreds-cheat-sheet
     add-history creds
     add-test-command "creds version"
-    add-to-list "creds,https://github.com/ihebski/DefaultCreds-cheat-sheet,One place for all the default credentials to assist pentesters during an engagement, this document has several products default login/password gathered from multiple sources."
+    add-to-list "creds,https://github.com/ihebski/DefaultCreds-cheat-sheet,One place for all the default credentials to assist pentesters during an engagement. This document has several products default login/password gathered from multiple sources."
 }
 
 # Package dedicated to offensive miscellaneous tools


### PR DESCRIPTION
# Description

Removed commas from tool descriptions to prevent incorrect parsing of documentation CSVs.
Changed the pipeline check so that it returns 1 when it detects a comma in the tool description.