### PR TITLE
Added '--run-as=root' for binwalk

### DIFF
--- a/sources/assets/shells/aliases.d/binwalk
+++ b/sources/assets/shells/aliases.d/binwalk
@@ -1,0 +1,1 @@
+alias binwalk='binwalk --run-as=root'

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -9,6 +9,7 @@ function install_forensic_apt_tools() {
     fapt pst-utils binwalk foremost testdisk fdisk sleuthkit
     
     add-history binwalk
+    add-aliases binwalk
     add-history foremost
     add-history testdisk
     add-history fdisk


### PR DESCRIPTION
# Description

Greetings,

This PR aims to supress the error message thrown by binwalk in case we don't specify that we want to run it as root using `--run-as=root`:
```
Extractor Exception: Binwalk extraction uses many third party utilities, which may not be secure. If you wish to have extraction utilities executed as the current user, use '--run-as=root' (binwalk itself must be run as root).
----------------------------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/binwalk/core/module.py", line 258, in __init__
    self.load()
  File "/usr/lib/python3/dist-packages/binwalk/modules/extractor.py", line 147, in load
    raise ModuleException("Binwalk extraction uses many third party utilities, which may not be secure. If you wish to have extraction utilities executed as the current user, use '--run-as=%s' (binwalk itself must be run as root)." % user_info.pw_name)
binwalk.core.exceptions.ModuleException: Binwalk extraction uses many third party utilities, which may not be secure. If you wish to have extraction utilities executed as the current user, use '--run-as=root' (binwalk itself must be run as root).
----------------------------------------------------------------------------------------------------
```

# Related issues

N/A

# Point of attention

While the binwalk warning is perfectly valid and make sense in a classical setup, I think in our case it doesn't really do much since we are running everything as root anyway. Correct me if I'm wrong though.
