### PR TITLE
Fix binwalk dependencies

### DIFF
--- a/sources/assets/shells/aliases.d/binwalk
+++ b/sources/assets/shells/aliases.d/binwalk
@@ -1,0 +1,1 @@
+alias binwalk='binwalk --run-as=root'

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -28,7 +28,6 @@ function install_forensic_apt_tools() {
 function install_binwalk() {
     colorecho "Installing binwalk"
     fapt squashfs-tools binwalk
-
     add-aliases binwalk
     add-history binwalk
     add-test-command "binwalk --help"

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -27,21 +27,7 @@ function install_forensic_apt_tools() {
 
 function install_binwalk() {
     colorecho "Installing binwalk"
-    fapt binwalk
-
-    # Install 'sasquatch', external needed by binwalk to handle squashfs
-    git clone https://github.com/devttys0/sasquatch
-
-    # https://github.com/devttys0/sasquatch/pull/56
-    local temp_fix_limit="2025-04-01"
-    if [[ "$(date +%Y%m%d)" -gt "$(date -d $temp_fix_limit +%Y%m%d)" ]]; then
-      criticalecho "Temp fix expired. Exiting."
-    else
-      git config --local user.email "local"
-      git config --local user.name "local"
-      local prs=("56")
-      for pr in "${prs[@]}"; do git fetch origin "pull/$pr/head:pull/$pr" && git merge --strategy-option theirs --no-edit "pull/$pr"; done
-    fi
+    fapt squashfs-tools binwalk
 
     add-history binwalk
     add-test-command "binwalk --help"

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -29,6 +29,7 @@ function install_binwalk() {
     colorecho "Installing binwalk"
     fapt squashfs-tools binwalk
 
+    add-aliases binwalk
     add-history binwalk
     add-test-command "binwalk --help"
     add-to-list "binwalk,https://github.com/ReFirmLabs/binwalk,Binwalk is a tool for analyzing / reverse engineering / and extracting firmware images."

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -6,26 +6,46 @@ source common.sh
 function install_forensic_apt_tools() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing forensic apt tools"
-    fapt pst-utils binwalk foremost testdisk fdisk sleuthkit
+    fapt pst-utils foremost testdisk fdisk sleuthkit
     
-    add-history binwalk
     add-history foremost
     add-history testdisk
     add-history fdisk
     
     add-test-command "pst2ldif -V"      # Reads a PST and prints the tree structure to the console
-    add-test-command "binwalk --help"   # Tool to find embedded files
     add-test-command "foremost -V"      # Alternative to binwalk
     add-test-command "testdisk --help"  # Recover lost partitions
     add-test-command "fdisk --help"     # Creating and manipulating disk partition table
     add-test-command "blkcalc -V"       # Collection of command line tools that allow you to investigate disk images
 
     add-to-list "pst-utils,https://manpages.debian.org/jessie/pst-utils/readpst.1,pst-utils is a set of tools for working with Outlook PST files."
-    add-to-list "binwalk,https://github.com/ReFirmLabs/binwalk,Binwalk is a tool for analyzing / reverse engineering / and extracting firmware images."
     add-to-list "foremost,https://doc.ubuntu-fr.org/foremost,Foremost is a forensic tool for recovering files based on their headers / footers / and internal data structures."
     add-to-list "testdisk,https://github.com/cgsecurity/testdisk,Partition recovery and file undelete utility"
     add-to-list "fdisk,https://github.com/karelzak/util-linux,Collection of basic system utilities / including fdisk partitioning tool"
     add-to-list "sleuthkit,https://github.com/sleuthkit/sleuthkit,Forensic toolkit to analyze volume and file system data"
+}
+
+function install_binwalk() {
+    colorecho "Installing binwalk"
+    fapt binwalk
+
+    # Install 'sasquatch', external needed by binwalk to handle squashfs
+    git clone https://github.com/devttys0/sasquatch
+
+    # https://github.com/devttys0/sasquatch/pull/56
+    local temp_fix_limit="2025-04-01"
+    if [[ "$(date +%Y%m%d)" -gt "$(date -d $temp_fix_limit +%Y%m%d)" ]]; then
+      criticalecho "Temp fix expired. Exiting."
+    else
+      git config --local user.email "local"
+      git config --local user.name "local"
+      local prs=("56")
+      for pr in "${prs[@]}"; do git fetch origin "pull/$pr/head:pull/$pr" && git merge --strategy-option theirs --no-edit "pull/$pr"; done
+    fi
+
+    add-history binwalk
+    add-test-command "binwalk --help"
+    add-to-list "binwalk,https://github.com/ReFirmLabs/binwalk,Binwalk is a tool for analyzing / reverse engineering / and extracting firmware images."
 }
 
 function install_volatility2() {
@@ -119,6 +139,7 @@ function package_forensic() {
     local end_time
     start_time=$(date +%s)
     install_forensic_apt_tools
+    install_binwalk                 # Tool to find embedded files
     install_volatility2             # Memory analysis tool
     install_volatility3             # Memory analysis tool v2
     install_trid                    # filetype detection tool


### PR DESCRIPTION
# Description

Greetings,

When running something along the line of: `binwalk -e test.sqhfs --run-as=root`, I get:
```
WARNING: Extractor.execute failed to run external extractor 'unsquashfs -d 'squashfs-root' '%e'': [Errno 2] No such file or directory: 'unsquashfs', 'unsquashfs -d 'squashfs-root' '%e'' might not be installed correctly
```

The `unsquashfs` dependency is not installed, this PR aim to fix that, it also move the binwalk install in it's own install function.

# Related issues

N/A

# Point of attention

Binwalk list other dependency such as `sasquatch` (https://github.com/ReFirmLabs/binwalk/blob/master/INSTALL.md), since I haven't encountered a case where those were needed I propose to add them later on if necessary.
