### PR TITLE
Fix typo in a Bloodhound custom query

### DIFF
--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -1039,7 +1039,7 @@
 			"queryList": [
 				{
 					"final": true,
-					"query": "MATCH p=(u:User {enabled, TRUE, plaintext: TRUE})-[:MemberOf*1..]->(g:Group {highvalue: TRUE}) RETURN p",
+					"query": "MATCH p=(u:User {enabled: TRUE, plaintext: TRUE})-[:MemberOf*1..]->(g:Group {highvalue: TRUE}) RETURN p",
 					"allowCollapse": true
 				}
 			]


### PR DESCRIPTION
This PR fixes a typo in a custom query for Bloodhound.