### PR TITLE
Bloodhound queries: improve outdated OS and top 10 users queries and misc fixes

### DIFF
--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -475,7 +475,7 @@
             "category": "Groups",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(m:Group)-[:ForceChangePassword]->(n:User) RETURN DISTINCT m[.]name,  COUNT(m[.]name) ORDER BY COUNT(m[.]name) DESC"
+                "query": "MATCH p=(m:Group)-[:ForceChangePassword]->(n:User) RETURN DISTINCT m.name, COUNT(m.name) ORDER BY COUNT(m.name) DESC"
             }]
         },
         {
@@ -993,7 +993,7 @@
             }]
         },
         {
-            "name": "Find Unsecured Certificate Templates - Domain Escalation (ESC9)",
+            "name": "Find insecure Certificate Templates - Domain Escalation (ESC9)",
             "category": "AD CS Domain Escalation",
             "queryList": [
                 {
@@ -1003,7 +1003,7 @@
             ]
         },
         {
-            "name": "Find Unsecured Certificate Templates - PKI (ESC9)",
+            "name": "Find insecure Certificate Templates - PKI (ESC9)",
             "category": "AD CS Domain Escalation",
             "queryList": [
                 {

--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -614,7 +614,7 @@
             "category": "Outdated OS",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c:Computer) WHERE toUpper(c.operatingsystem) CONTAINS 'XP' RETURN c"
+                "query": "MATCH (c:Computer {enabled: TRUE}) WHERE toUpper(c.operatingsystem) CONTAINS 'XP' RETURN c"
             }]
         },
         {
@@ -622,7 +622,7 @@
             "category": "Outdated OS",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c:Computer) WHERE toUpper(c.operatingsystem) CONTAINS '2000' RETURN c"
+                "query": "MATCH (c:Computer {enabled: TRUE}) WHERE toUpper(c.operatingsystem) CONTAINS '2000' RETURN c"
             }]
         },
         {
@@ -630,7 +630,7 @@
             "category": "Outdated OS",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c:Computer) WHERE toUpper(c.operatingsystem) CONTAINS '2003' RETURN c"
+                "query": "MATCH (c:Computer {enabled: TRUE}) WHERE toUpper(c.operatingsystem) CONTAINS '2003' RETURN c"
             }]
         },
         {
@@ -638,7 +638,7 @@
             "category": "Outdated OS",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c:Computer) WHERE toUpper(c.operatingsystem) CONTAINS '2008' RETURN c"
+                "query": "MATCH (c:Computer {enabled: TRUE}) WHERE toUpper(c.operatingsystem) CONTAINS '2008' RETURN c"
             }]
         },
         {
@@ -646,7 +646,7 @@
             "category": "Outdated OS",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c:Computer) WHERE toUpper(c.operatingsystem) CONTAINS 'VISTA' RETURN c"
+                "query": "MATCH (c:Computer {enabled: TRUE}) WHERE toUpper(c.operatingsystem) CONTAINS 'VISTA' RETURN c"
             }]
         },
         {
@@ -654,7 +654,7 @@
             "category": "Outdated OS",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (c:Computer) WHERE toUpper(c.operatingsystem) CONTAINS '7' RETURN c"
+                "query": "MATCH (c:Computer {enabled: TRUE}) WHERE toUpper(c.operatingsystem) CONTAINS '7' RETURN c"
             }]
         },
         {
@@ -662,7 +662,7 @@
             "category": "Top Ten",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User),(m:Computer), (n)<-[r:HasSession]-(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH n, count(r) AS rel_count order by rel_count desc LIMIT 10 MATCH p=(m)-[r:HasSession]->(n) RETURN p",
+                "query": "MATCH (n:User {enabled: TRUE})<-[r:HasSession]-(m:Computer {enabled: TRUE}) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH n, COUNT(r) AS rel_count ORDER BY rel_count DESC LIMIT 10 MATCH p=(m)-[r:HasSession]->(n) RETURN p",
                 "allowCollapse": true
             }]
         },
@@ -671,43 +671,43 @@
             "category": "Top Ten",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User),(m:Computer), (n)<-[r:HasSession]-(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) AS rel_count order by rel_count desc LIMIT 10 MATCH p=(m)-[r:HasSession]->(n) RETURN p",
+                "query": "MATCH (n:User {enabled: TRUE})<-[r:HasSession]-(m:Computer {enabled: TRUE}) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, COUNT(r) AS rel_count ORDER BY rel_count DESC LIMIT 10 MATCH p=(m)-[:HasSession]->(n) RETURN p",
                 "allowCollapse": true
             }]
         },
         {
-            "name": "Top Ten Users with Most Local Admin Rights",
+            "name": "Top Ten Users (not Domain Admins or Entreprise Admins) with most local admin rights",
             "category": "Top Ten",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH n, count(r) AS rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) RETURN p",
+                "query": "MATCH (u:User {enabled: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' WITH COLLECT(u.objectid) AS domainAdmins MATCH (n:User {enabled: TRUE})-[r:AdminTo]->(m:Computer {enabled: TRUE}) WHERE NOT n.objectid IN domainAdmins AND NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT  n.name='' WITH n, COUNT(r) AS rel_count ORDER BY rel_count DESC LIMIT 10 MATCH p=(n)-[:AdminTo]->(m:Computer {enabled: TRUE}) RETURN p",
                 "allowCollapse": true
             }]
         },
         {
-            "name": "Top Ten Computers with Most Admins and their admins",
+            "name": "Top Ten Computers with most local admin rights (not Domain Admins or Entreprise Admins) and their admins",
             "category": "Top Ten",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) AS rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) RETURN p",
+                "query": "MATCH (u:User {enabled: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' WITH COLLECT(u.objectid) AS domainAdmins MATCH (n:User {enabled: TRUE})-[r:AdminTo]->(m:Computer {enabled: TRUE}) WHERE NOT n.objectid IN domainAdmins AND NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, COUNT(r) AS rel_count ORDER BY rel_count DESC LIMIT 10 MATCH p=(m)<-[:AdminTo]-(n:User {enabled: TRUE}) RETURN p",
                 "allowCollapse": true
             }]
         },
         {
-            "name": "Top Ten Computers with Most Admins",
+            "name": "Top Ten Computers with most admins (not Domain Admins or Entreprise Admins)",
             "category": "Top Ten",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) AS rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) RETURN m",
+                "query": "MATCH (u:User {enabled: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' WITH COLLECT(u.objectid) AS domainAdmins MATCH (n:User {enabled: TRUE})-[r:AdminTo]->(m:Computer {enabled: TRUE}) WHERE NOT n.objectid IN domainAdmins AND NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, COUNT(r) AS rel_count ORDER BY rel_count DESC LIMIT 10 MATCH (m)<-[:AdminTo]-(o:User {enabled: TRUE}) RETURN m",
                 "allowCollapse": true
             }]
         },
         {
-            "name": "(Warning: edits the DB) Mark Top Ten Computers with Most Admins as HVT",
+            "name": "(Warning: edits the DB) Mark Top Ten Computers with most admins (not Domain Admins or Entreprise Admins) as HVT",
             "category": "Top Ten",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (n:User),(m:Computer), (n)-[r:AdminTo]->(m) WHERE NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, count(r) AS rel_count order by rel_count desc LIMIT 10 MATCH p=(m)<-[r:AdminTo]-(n) SET m.highvalue = true RETURN m",
+                "query": "MATCH (u:User {enabled: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' WITH COLLECT(u.objectid) AS domainAdmins MATCH (n:User {enabled: TRUE})-[r:AdminTo]->(m:Computer {enabled: TRUE}) WHERE NOT n.objectid IN domainAdmins AND NOT n.name STARTS WITH 'ANONYMOUS LOGON' AND NOT n.name='' WITH m, COUNT(r) AS rel_count ORDER BY rel_count DESC LIMIT 10 MATCH (m)<-[:AdminTo]-(o:User {enabled: TRUE}) SET m.highvalue = true RETURN m",
                 "allowCollapse": true
             }]
         },


### PR DESCRIPTION
Hello,

this PR modifies some Bloodhound custom queries.

- Outdated OS:
Instead of returning every outdated computers referenced in the AD, only return the ones which machine account is enabled.
Indeed, returning a disabled Windows XP is not interesting.

- Top 10 user sessions:
The queries were returning the top 10 users with local admin rights. So basically, it was also returning the domain administrators with admin rights on all object computers including the domain controllers. And if the domain has more than 10 DA, then these are the only ones returned.

The modified queries only return the top 10 users who are neither Domain Admins, Enterprise Admins, nor Administrators.

- Misc:
Fix a broken query and an english typo