### PR TITLE
Fixed a bug allowing configuration updates following Responder update

### DIFF
--- a/sources/assets/shells/aliases.d/responder
+++ b/sources/assets/shells/aliases.d/responder
@@ -1,8 +1,8 @@
 function MultiRelay.py { (cd /opt/tools/Responder/tools/ && /opt/tools/Responder/venv/bin/python3 /opt/tools/Responder/tools/MultiRelay.py "$@") }
 alias RunFinger.py='/opt/tools/Responder/venv/bin/python3 /opt/tools/Responder/tools/RunFinger.py'
 alias Responder.py='/opt/tools/Responder/venv/bin/python3 /opt/tools/Responder/Responder.py'
-alias responder-http-on="sed -i 's/HTTP = Off/HTTP = On/g' /opt/tools/Responder/Responder.conf && cat /opt/tools/Responder/Responder.conf | grep --color=never 'HTTP ='"
-alias responder-http-off="sed -i 's/HTTP = On/HTTP = Off/g' /opt/tools/Responder/Responder.conf && cat /opt/tools/Responder/Responder.conf | grep --color=never 'HTTP ='"
-alias responder-smb-on="sed -i 's/SMB = Off/SMB = On/g' /opt/tools/Responder/Responder.conf && cat /opt/tools/Responder/Responder.conf | grep --color=never 'SMB ='"
-alias responder-smb-off="sed -i 's/SMB = On/SMB = Off/g' /opt/tools/Responder/Responder.conf && cat /opt/tools/Responder/Responder.conf | grep --color=never 'SMB ='"
+alias responder-http-on="sed -i -E 's/^HTTP( +)= Off/HTTP = On/g' /opt/tools/Responder/Responder.conf && cat /opt/tools/Responder/Responder.conf | grep --color=never 'HTTP ='"
+alias responder-http-off="sed -i -E 's/^HTTP( +)= On/HTTP = Off/g' /opt/tools/Responder/Responder.conf && cat /opt/tools/Responder/Responder.conf | grep --color=never 'HTTP ='"
+alias responder-smb-on="sed -i -E 's/^SMB( +)= Off/SMB = On/g' /opt/tools/Responder/Responder.conf && cat /opt/tools/Responder/Responder.conf | grep --color=never 'SMB ='"
+alias responder-smb-off="sed -i -E 's/^SMB( +)= On/SMB = Off/g' /opt/tools/Responder/Responder.conf && cat /opt/tools/Responder/Responder.conf | grep --color=never 'SMB ='"
 alias responder="Responder.py"


### PR DESCRIPTION
# Description

Responder configuration has been updated (<https://github.com/lgandx/Responder/commit/807bd57a96337ab77f2fff50729a6eb229e5dc37>).
The current `sed` command no longer matches the new configuration file.
I've added a regex with spaces to make this version backwards-compatible.

# Point of attention

I tested it on the latest version of nightly and the new alias works well.

Before :

![Before](https://github.com/user-attachments/assets/c98aeb66-d13b-43b5-a9a3-3936504c2122)

After :

![After](https://github.com/user-attachments/assets/4e8818be-3382-4927-80b3-c2b6146dd64a)

