### PR TITLE
Modified BH customqueries to find T0 assets

### DIFF
--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -33,19 +33,27 @@
             }]
         },
         {
-            "name": "Find objects containing names of some tier 0 software (SCCM, Veeam, ...)",
+            "name": "Find enabled objects containing names/descriptions of some tier 0 software (Azure, SCCM, Veeam, ...)",
             "category": "High Value Targets",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (o) WHERE (o.samaccountname =~ '(?i).*(?:sccm|veeam|boomgar|tivoli|altiris|varonis|vcenter|vsphere|esx).*') RETURN o"
+                "query": "WITH '(?i).*(?:azure|sccm|mecm|veeam|acronis|boomgar|tivoli|altiris|varonis|vcenter|vsphere|esx).*' AS keyword MATCH (o {enabled: TRUE}) WHERE o.samaccountname =~ keyword OR o.description =~ keyword OR o.name =~ keyword RETURN o"
             }]
         },
         {
-            "name": "(Warning: edits the DB) Mark objects containing names of some tier 0 software (SCCM, Veeam, ...) as HVT",
+            "name": "(Warning: edits the DB) Mark enabled objects containing names/descriptions of some tier 0 software (Azure, SCCM, Veeam, ...) as HVT",
             "category": "High Value Targets",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (o) WHERE (o.samaccountname =~ '(?i).*(?:sccm|veeam|boomgar|tivoli|altiris|varonis|vcenter|vsphere|esx).*') SET o.highvalue=TRUE RETURN o"
+                "query": "WITH '(?i).*(?:azure|sccm|mecm|veeam|acronis|boomgar|tivoli|altiris|varonis|vcenter|vsphere|esx).*' AS keyword MATCH (o {enabled: TRUE}) WHERE o.samaccountname =~ keyword OR o.description =~ keyword OR o.name =~ keyword SET o.highvalue=TRUE RETURN o"
+            }]
+        },
+        {
+            "name": "Find enabled computers containing SPNs with some tier 0 software (Azure, SCCM, Veeam, ...) as HVT",
+            "category": "High Value Targets",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH (c:Computer {enabled: TRUE}) WHERE SIZE(c.serviceprincipalnames) > 0 UNWIND [s IN c.serviceprincipalnames WHERE s =~ '(?i).*(?:azure|sccm|mecm|veeam|acronis|boomgar|tivoli|altiris|varonis|vcenter|vsphere|esx).*'] AS spn WITH c, spn WHERE SIZE(spn) > 0 return c"
             }]
         },
         {


### PR DESCRIPTION
# Description

* Updating 2 Bloodhound custom queries used to find Tier 0 objects in the AD to search in a broader way.
* Adding a new Bloodhound custom query to find enabled Tier 0 computers based on their Service Principal Names (SPNs). Useful when you are looking for backup servers located in the domain which have random computer names and/or descriptions.

# Related issues

I forgot to sign the commits in my previous PR #384...

# Point of attention

The words used in the new query which parses SPNs could be tailored more accurately. I do not have enough Bloodhound data for now to offer a more accurate filter. Feel free to change it with your own list during your internal assessments.
