### PR TITLE
Update faketime history

### DIFF
--- a/sources/assets/shells/history.d/faketime
+++ b/sources/assets/shells/history.d/faketime
@@ -1,1 +1,2 @@
 faketime '2022-01-31 22:05:35' zsh
+faketime "$(rdate -n $DC_IP -p | awk '{print $2, $3, $4}' | date -f - "+%Y-%m-%d %H:%M:%S")" zsh


### PR DESCRIPTION
Added in history lazier cmd to faketime with rdate

# Description

> Added a command in history that allows to faketime exactly at the time of a target, combining it with rdate. No more approximative faketime! We are too lazy for that!
