### PR TITLE
Small typo in BloodHound customqueries.json: change comma to colon

### DIFF
--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -1039,7 +1039,7 @@
 			"queryList": [
 				{
 					"final": true,
-					"query": "MATCH p=(u:User {enabled, TRUE, plaintext: TRUE})-[:MemberOf*1..]->(g:Group {highvalue: TRUE}) RETURN p",
+					"query": "MATCH p=(u:User {enabled: TRUE, plaintext: TRUE})-[:MemberOf*1..]->(g:Group {highvalue: TRUE}) RETURN p",
 					"allowCollapse": true
 				}
 			]


### PR DESCRIPTION
There was a small typo in one of the queries that brought up a graph error. Changed the comma to a colon. 

Thanks for putting out the configuration.