### PR TITLE
Fix bloodhound-ce collectors

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -192,10 +192,14 @@ function install_bloodhound-ce() {
     ## AzureHound
     local AZUREHOUND_URL_AMD64
     local AZUREHOUND_URL_ARM64
+    local AZUREHOUND_VERSION
+    AZUREHOUND_VERSION=$(curl --location --silent "https://api.github.com/repos/BloodHoundAD/AzureHound/releases/latest" | grep 'azurehound-linux-arm64.zip' | grep -v 'sha' | grep -oP 'v\d+.\d.\d+')
     AZUREHOUND_URL_AMD64=$(curl --location --silent "https://api.github.com/repos/BloodHoundAD/AzureHound/releases/latest" | grep 'azurehound-linux-arm64.zip' | grep -v 'sha' | grep -o 'https://[^"]*')
     AZUREHOUND_URL_ARM64=$(curl --location --silent "https://api.github.com/repos/BloodHoundAD/AzureHound/releases/latest" | grep 'azurehound-linux-amd64.zip' | grep -v 'sha' | grep -o 'https://[^"]*')
     wget --directory-prefix /opt/tools/BloodHound-CE/collectors/azurehound/ "$AZUREHOUND_URL_AMD64"
     wget --directory-prefix /opt/tools/BloodHound-CE/collectors/azurehound/ "$AZUREHOUND_URL_ARM64"
+    7z a -tzip -mx9 "/opt/tools/BloodHound-CE/collectors/azurehound/azurehound-$AZUREHOUND_VERSION.zip" "/opt/tools/BloodHound-CE/collectors/azurehound/azurehound-*"
+    sha256sum "/opt/tools/BloodHound-CE/collectors/azurehound/azurehound-$AZUREHOUND_VERSION.zip" > "/opt/tools/BloodHound-CE/collectors/azurehound/azurehound-$AZUREHOUND_VERSION.zip.sha256"
 
     # Files and directories
     # work directory required by bloodhound


### PR DESCRIPTION
# Description

The current bloodhound-ce installation is broken. The collectors page returns the following errors
![image](https://github.com/user-attachments/assets/bb1a1db8-bb00-4e36-bc33-910e87d620e0)

In fact, no Azurehound collectors is found. Bloodhound-ce expect the Azurehound and Sharphound archive to follow a nomenclature: https://github.com/SpecterOps/BloodHound/blob/403c45c041f36c2e80db6c5922f298ee6484fff8/cmd/api/src/api/v2/collectors.go#L32 

The version should be in the named of the archive (i.e: SharpHound-v2.4.1.zip). This PR fix this issue by retrieving the azurehound version and creating an archive with the arm and amd binary