### PR TITLE
Improve Sharphound and Azurehound installations

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -158,9 +158,16 @@ function install_bloodhound-ce() {
     # CODE-CHECK-WHITELIST=add-aliases,add-history
     colorecho "Installing BloodHound-CE"
 
+    # Ingestors: bloodhound-ce requires the ingestors to be in a specific directory and checks that when starting, they need to be downloaded here
     local bloodhoundce_path="/opt/tools/BloodHound-CE/"
     local sharphound_path="${bloodhoundce_path}/collectors/sharphound/"
     local azurehound_path="${bloodhoundce_path}/collectors/azurehound/"
+    mkdir -p "${bloodhoundce_path}"
+    mkdir -p "${sharphound_path}"
+    mkdir -p "${azurehound_path}"
+
+    local curl_tempfile=$(mktemp)
+    [[ -f "${curl_tempfile}" ]] || exit
 
     # Installing & Configuring the database
     fapt postgresql postgresql-client
@@ -177,55 +184,44 @@ function install_bloodhound-ce() {
     service postgresql stop
 
     # Build BloodHound-CE
-    mkdir -p "${bloodhoundce_path}"
     local latestRelease
-    latestRelease=$(curl -s https://api.github.com/repos/SpecterOps/BloodHound/releases | jq -r 'map(.tag_name | select(contains("-rc") | not))[0]')
-    git -C "${bloodhoundce_path}" clone --depth 1 --branch "${latestRelease}" https://github.com/SpecterOps/BloodHound.git src
+    # Had to output into a tempfile as the Exegol's wrapper for curl breaks stdout
+    curl --location --silent "https://api.github.com/repos/SpecterOps/BloodHound/releases" -o "${curl_tempfile}"
+    latestRelease=$(jq --raw-output 'first(.[] | select(.tag_name | contains("-rc") | not) | .tag_name)' "${curl_tempfile}")
+    git -C "${bloodhoundce_path}" clone --depth 1 --branch "${latestRelease}" "https://github.com/SpecterOps/BloodHound.git" src
     cd "${bloodhoundce_path}/src/packages/javascript/bh-shared-ui" || exit
     zsh -c "source ~/.zshrc && nvm install 18 && nvm use 18 && yarn install --immutable && yarn build"
     cd "${bloodhoundce_path}/src/" || exit
     asdf local golang 1.23.0
     catch_and_retry VERSION=v999.999.999 CHECKOUT_HASH="" python3 ./packages/python/beagle/main.py build --verbose --ci
 
-    # Ingestors: bloodhound-ce requires the ingestors to be in a specific directory and checks that when starting, they need to be downloaded here
-    mkdir -p "${sharphound_path}"
-    mkdir -p "${azurehound_path}"
-
     ## SharpHound
-    local sharphound_latest_tempfile
     local sharphound_url
     local sharphound_name
     local sharphound_name_lowercase
-    sharphound_latest_tempfile=$(mktemp)
-    [[ -f ${sharphound_latest_tempfile} ]] || exit
-    curl --location --silent "https://api.github.com/repos/BloodHoundAD/SharpHound/releases/latest" > "${sharphound_latest_tempfile}"
-    sharphound_url=$(jq --raw-output '.assets[].browser_download_url | select(contains("debug") | not)' "${sharphound_latest_tempfile}")
-    sharphound_name=$(jq --raw-output '.assets[].name | select(contains("debug") | not)' "${sharphound_latest_tempfile}")
+    curl --location --silent "https://api.github.com/repos/BloodHoundAD/SharpHound/releases/latest" -o "${curl_tempfile}"
+    sharphound_url=$(jq --raw-output '.assets[].browser_download_url | select(contains("debug") | not)' "${curl_tempfile}")
+    sharphound_name=$(jq --raw-output '.assets[].name | select(contains("debug") | not)' "${curl_tempfile}")
     # lowercase fix: https://github.com/ThePorgs/Exegol-images/pull/405
-    sharphound_name_lowercase=$(jq --raw-output '.assets[].name | ascii_downcase | select(contains("debug") | not)' "${sharphound_latest_tempfile}")
-    rm "${sharphound_latest_tempfile}"
+    sharphound_name_lowercase=$(jq --raw-output '.assets[].name | ascii_downcase | select(contains("debug") | not)' "${curl_tempfile}")
     wget --directory-prefix "${sharphound_path}" "${sharphound_url}"
     [[ -f "${sharphound_path}/${sharphound_name}" ]] || exit
     mv "${sharphound_path}/${sharphound_name}" "${sharphound_path}/${sharphound_name_lowercase}"
     # Unlike Azurehound, upstream does not provide a sha256 file to check the integrity
 
     ## AzureHound
-    local azurehound_latest_tempfile
     local azurehound_url_amd64
     local azurehound_url_amd64_sha256
     local azurehound_url_arm64
     local azurehound_url_arm64_sha256
     local azurehound_version
-
-    azurehound_latest_tempfile=$(mktemp)
-    [[ -f "${azurehound_latest_tempfile}" ]] || exit
-    curl --location --silent "https://api.github.com/repos/BloodHoundAD/AzureHound/releases/latest" > "${azurehound_latest_tempfile}"
-    azurehound_version=$(jq --raw-output '.tag_name' "${azurehound_latest_tempfile}")
-    azurehound_url_amd64=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-amd64.zip"))' "${azurehound_latest_tempfile}")
-    azurehound_url_amd64_sha256=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-amd64.zip.sha256"))' "${azurehound_latest_tempfile}")
-    azurehound_url_arm64=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-arm64.zip"))' "${azurehound_latest_tempfile}")
-    azurehound_url_arm64_sha256=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-arm64.zip.sha256"))' "${azurehound_latest_tempfile}")
-    rm "${azurehound_latest_tempfile}"
+    curl --location --silent "https://api.github.com/repos/BloodHoundAD/AzureHound/releases/latest" -o "${curl_tempfile}"
+    azurehound_version=$(jq --raw-output '.tag_name' "${curl_tempfile}")
+    azurehound_url_amd64=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-amd64.zip"))' "${curl_tempfile}")
+    azurehound_url_amd64_sha256=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-amd64.zip.sha256"))' "${curl_tempfile}")
+    azurehound_url_arm64=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-arm64.zip"))' "${curl_tempfile}")
+    azurehound_url_arm64_sha256=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-arm64.zip.sha256"))' "${curl_tempfile}")
+    rm "${curl_tempfile}"
     wget --directory-prefix "${azurehound_path}" "${azurehound_url_amd64}"
     [[ -f "${azurehound_path}/azurehound-linux-amd64.zip" ]] || exit
     wget --directory-prefix "${azurehound_path}" "${azurehound_url_amd64_sha256}"
@@ -239,7 +235,7 @@ function install_bloodhound-ce() {
 
     # Files and directories
     # work directory required by bloodhound
-    mkdir "${bloodhoundce_path}/work"
+    mkdir -p "${bloodhoundce_path}/work"
     ln -v -s "${bloodhoundce_path}/src/artifacts/bhapi" "${bloodhoundce_path}/bloodhound"
     cp -v "${bloodhoundce_path}/src/dockerfiles/configs/bloodhound.config.json" "${bloodhoundce_path}"
     cp -v /root/sources/assets/bloodhound-ce/* /opt/tools/bin/

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -198,10 +198,10 @@ function install_bloodhound-ce() {
     sharphound_latest_tempfile=$(mktemp)
     [[ -f ${sharphound_latest_tempfile} ]] || exit
     curl --location --silent "https://api.github.com/repos/BloodHoundAD/SharpHound/releases/latest" > "${sharphound_latest_tempfile}"
-    sharphound_url=$(jq --raw-output '.assets[].browser_download_url | select(contains("debug") | not)' ${sharphound_latest_tempfile})
-    sharphound_name=$(jq --raw-output '.assets[].name | select(contains("debug") | not)' ${sharphound_latest_tempfile})
+    sharphound_url=$(jq --raw-output '.assets[].browser_download_url | select(contains("debug") | not)' "${sharphound_latest_tempfile}")
+    sharphound_name=$(jq --raw-output '.assets[].name | select(contains("debug") | not)' "${sharphound_latest_tempfile}")
     # lowercase fix: https://github.com/ThePorgs/Exegol-images/pull/405
-    sharphound_name_lowercase=$(jq --raw-output '.assets[].name | ascii_downcase | select(contains("debug") | not)' ${sharphound_latest_tempfile})
+    sharphound_name_lowercase=$(jq --raw-output '.assets[].name | ascii_downcase | select(contains("debug") | not)' "${sharphound_latest_tempfile}")
     rm "${sharphound_latest_tempfile}"
     wget --directory-prefix "${sharphound_path}" "${sharphound_url}"
     [[ -f "${sharphound_path}/${sharphound_name}" ]] || exit
@@ -220,10 +220,10 @@ function install_bloodhound-ce() {
     [[ -f ${azurehound_latest_tempfile} ]] || exit
     curl --location --silent "https://api.github.com/repos/BloodHoundAD/AzureHound/releases/latest" > "${azurehound_latest_tempfile}"
     azurehound_version=$(jq --raw-output '.tag_name' "${azurehound_latest_tempfile}")
-    azurehound_url_amd64=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-amd64.zip"))' ${azurehound_latest_tempfile})
-    azurehound_url_amd64_sha256=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-amd64.zip.sha256"))' ${azurehound_latest_tempfile})
-    azurehound_url_arm64=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-arm64.zip"))' ${azurehound_latest_tempfile})
-    azurehound_url_arm64_sha256=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-arm64.zip.sha256"))' ${azurehound_latest_tempfile})
+    azurehound_url_amd64=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-amd64.zip"))' "${azurehound_latest_tempfile}")
+    azurehound_url_amd64_sha256=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-amd64.zip.sha256"))' "${azurehound_latest_tempfile}")
+    azurehound_url_arm64=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-arm64.zip"))' "${azurehound_latest_tempfile}")
+    azurehound_url_arm64_sha256=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-arm64.zip.sha256"))' "${azurehound_latest_tempfile}")
     rm "${azurehound_latest_tempfile}"
     wget --directory-prefix "${azurehound_path}" "${azurehound_url_amd64}"
     [[ -f "${azurehound_path}/azurehound-linux-amd64.zip" ]] || exit

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -233,7 +233,7 @@ function install_bloodhound-ce() {
     [[ -f "${azurehound_path}/azurehound-linux-arm64.zip" ]] || exit
     wget --directory-prefix "${azurehound_path}" "${azurehound_url_arm64_sha256}"
     [[ -f "${azurehound_path}/azurehound-linux-arm64.zip.sha256" ]] || exit
-    (cd "${azurehound_path}"; sha256sum --check --warn *.sha256) || exit
+    (cd "${azurehound_path}"; sha256sum --check --warn ./*.sha256) || exit
     7z a -tzip -mx9 "${azurehound_path}/azurehound-${azurehound_version}.zip" "${azurehound_path}/azurehound-*"
 
     # Files and directories

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -217,7 +217,7 @@ function install_bloodhound-ce() {
     local azurehound_version
 
     azurehound_latest_tempfile=$(mktemp)
-    [[ -f ${azurehound_latest_tempfile} ]] || exit
+    [[ -f "${azurehound_latest_tempfile}" ]] || exit
     curl --location --silent "https://api.github.com/repos/BloodHoundAD/AzureHound/releases/latest" > "${azurehound_latest_tempfile}"
     azurehound_version=$(jq --raw-output '.tag_name' "${azurehound_latest_tempfile}")
     azurehound_url_amd64=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-amd64.zip"))' "${azurehound_latest_tempfile}")

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -224,7 +224,7 @@ function install_bloodhound-ce() {
     azurehound_url_amd64_sha256=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-amd64.zip.sha256"))' ${azurehound_latest_tempfile})
     azurehound_url_arm64=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-arm64.zip"))' ${azurehound_latest_tempfile})
     azurehound_url_arm64_sha256=$(jq --raw-output '.assets[].browser_download_url | select (endswith("azurehound-linux-arm64.zip.sha256"))' ${azurehound_latest_tempfile})
-    rm ${azurehound_latest_tempfile}
+    rm "${azurehound_latest_tempfile}"
     wget --directory-prefix "${azurehound_path}" "${azurehound_url_amd64}"
     [[ -f "${azurehound_path}/azurehound-linux-amd64.zip" ]] || exit
     wget --directory-prefix "${azurehound_path}" "${azurehound_url_amd64_sha256}"

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -166,7 +166,8 @@ function install_bloodhound-ce() {
     mkdir -p "${sharphound_path}"
     mkdir -p "${azurehound_path}"
 
-    local curl_tempfile=$(mktemp)
+    local curl_tempfile
+    curl_tempfile=$(mktemp)
     [[ -f "${curl_tempfile}" ]] || exit
 
     # Installing & Configuring the database


### PR DESCRIPTION
Howdy,

this PR aims at improving the installation of the ingestors Sharphound and Azurehound for Bloodhound-CE:
- the case of local variables is switched from uppercase to lowercase for consistency across Exegol
- local paths are put into a variable instead of repeating each time the same paths
- instead of Curling the same Github page several times, the result is put once into a `temporary file`
- instead of `Grepping` the json output of Github, the temporary file is parsed with `jq`
- fix the variable `azurehound_url_amd64` that was containing the `arm64` URL, and the other way around the arm64 variable contained the amd64 URL
- A sha256 file was computed locally but nothing was done with it. Instead, the sha256files for Azurehound are downloaded from Github and the integrity of the zip archives is check prior to unzipping them.
- As upstream does not provide a sha256 file for Sharphound, the file computed locally is removed in order to not give a false impression that it was downloaded from Github.