### PR TITLE
evol: added bookmarks and extension in firefox

### DIFF
--- a/sources/assets/firefox/setup.py
+++ b/sources/assets/firefox/setup.py
@@ -28,7 +28,8 @@ urls = [
     "https://addons.mozilla.org/en-US/firefox/addon/darkreader/",
     "https://addons.mozilla.org/en-US/firefox/addon/uaswitcher/",
     "https://addons.mozilla.org/en-US/firefox/addon/cookie-editor/",
-    "https://addons.mozilla.org/en-US/firefox/addon/wappalyzer/"
+    "https://addons.mozilla.org/en-US/firefox/addon/wappalyzer/",
+    "https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers/"
 ]
 
 # Define regex


### PR DESCRIPTION
# Description

- Just a simple PR that add firefox multi-account containers to exegol this will surely save time and no need of using foxyproxy that uses entire firefox windows

- Add useful bookmarks (rootme-org and rev shell generator)