### PR TITLE
Update smbclient-ng history

### DIFF
--- a/sources/assets/shells/history.d/smbclient-ng
+++ b/sources/assets/shells/history.d/smbclient-ng
@@ -1,2 +1,2 @@
-smbclientng -d "$DOMAIN" -u "$USER" -p "$PASSWORD" --target "$DC_IP"
-smbng -d "$DOMAIN" -u "$USER" -p "$PASSWORD" --target "$DC_IP"
+smbclientng -d "$DOMAIN" -u "$USER" -p "$PASSWORD" --host "$DC_IP"
+smbng -d "$DOMAIN" -u "$USER" -p "$PASSWORD" --host "$DC_IP"


### PR DESCRIPTION
# Description
This PR aims to fix the arguments of `smbclient-ng`, the `--target` switch has changed to `--host`.

# Related issues

N / A

# Point of attention

N / A