### PR TITLE
BH Customqueries: add detection for RID 500 administrator impersonation and more

### DIFF
--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -463,7 +463,7 @@
             }]
         },
         {
-            "name": "Enabled Domain/Enterprise Administrators, Account/Backup/Print/Server Operators/..., not sensitive for delegation and not members of Protected Users",
+            "name": "Enabled Domain/Enterprise Administrators, Account/Backup/Print/Server Operators,... not sensitive for delegation and not members of Protected Users",
             "category": "Admins",
             "queryList": [{
                 "final": true,

--- a/sources/assets/bloodhound/customqueries.json
+++ b/sources/assets/bloodhound/customqueries.json
@@ -459,15 +459,15 @@
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User {enabled:TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '(?i)S-1-5-.*-525$' WITH COLLECT (u.objectid) AS protectedUsers MATCH p=(u2:User {enabled:TRUE, admincount:TRUE, sensitive:FALSE})-[:MemberOf*1..3]->(g2:Group) WHERE NOT u2.objectid IN protectedUsers RETURN p"
+                "query": "MATCH (u:User {enabled:TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '(?i)S-1-5-.*-525$' WITH COLLECT (u.objectid) AS protectedUsers MATCH p=(u2:User {enabled:TRUE, admincount:TRUE, sensitive:FALSE})-[:MemberOf*1..3]->(g2:Group) WHERE (NOT u2.objectid IN protectedUsers OR u2.objectid =~ '.*-500$') RETURN p"
             }]
         },
         {
-            "name": "Enabled Domain/Enterprise Administrators, not sensitive for delegation and not members of Protected Users",
+            "name": "Enabled Domain/Enterprise Administrators, Account/Backup/Print/Server Operators/..., not sensitive for delegation and not members of Protected Users",
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User {enabled: TRUE, admincount: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-525$' WITH COLLECT(u.objectid) AS protectedUsers MATCH p=(u2:User {enabled: TRUE, admincount: TRUE, sensitive: FALSE})-[:MemberOf*1..]->(g2:Group) WHERE NOT u2.objectid IN protectedUsers AND g2.objectid =~ '.*-(512|519|(?i)S-1-5-32-544)$' RETURN p"
+                "query": "MATCH (u:User {enabled: TRUE, admincount: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-525$' WITH COLLECT(u.objectid) AS protectedUsers MATCH p=(u2:User {enabled: TRUE, admincount: TRUE, sensitive: FALSE})-[:MemberOf*1..]->(g2:Group) WHERE (NOT u2.objectid IN protectedUsers OR u2.objectid =~ '.*-500$') AND g2.objectid =~ '.*-(512|517|518|519|544|548|549|550|551|574|583)$' RETURN p"
             }]
         },
         {
@@ -475,7 +475,7 @@
             "category": "Admins",
             "queryList": [{
                 "final": true,
-                "query": "MATCH (u:User {enabled: TRUE, admincount: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-525$' WITH COLLECT (u.objectid) AS protectedUsers MATCH p=(u2:User {enabled: TRUE, sensitive: FALSE})-[:MemberOf*1..]->(g2:Group {highvalue: TRUE}) WHERE NOT u2.objectid IN protectedUsers RETURN p"
+                "query": "MATCH (u:User {enabled: TRUE, admincount: TRUE})-[:MemberOf*1..]->(g:Group) WHERE g.objectid =~ '.*-525$' WITH COLLECT (u.objectid) AS protectedUsers MATCH p=(u2:User {enabled: TRUE, sensitive: FALSE})-[:MemberOf*1..]->(g2:Group {highvalue: TRUE}) WHERE (NOT u2.objectid IN protectedUsers OR u2.objectid =~ '.*-500$') RETURN p"
             }]
         },
         {


### PR DESCRIPTION
This PR aims at improving a few bloodhound custom queries dealing with the detection of privileged users that one can pick to impersonate (S4U2Self abuse, RBCD).

In particular, it deals with the special case of the RID 500 Administrator group as per the following blog post:
https://sensepost.com/blog/2023/protected-users-you-thought-you-were-safe-uh/

In details, it returns as an impersonation candidate the RID 500 Administrator account when it is not marked `sensitive and cannot be delegated`, even if the account is a member of the group `Protected Users`.

In addition, one query that was listing accounts to impersonate from the DA, EA and Administrator groups was expanded to include additional interesting built-in groups. Some of them also allows to log on for instance.