### PR TITLE
fix(ad): rename roadtools to roadrecon and add roadtx

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1197,16 +1197,7 @@ function install_noPac() {
 function install_roadrecon() {
     # CODE-CHECK-WHITELIST=add-aliases,add-history
     colorecho "Installing roadrecon"
-    # pipx install --system-site-packages roadrecon[road2timeline]
-    # Install dependencies of road2timeline plugin
-    # see https://github.com/dirkjanm/ROADtools/pull/121
-    local temp_fix_limit="2025-04-01"
-    if [[ "$(date +%Y%m%d)" -gt "$(date -d $temp_fix_limit +%Y%m%d)" ]]; then
-      criticalecho "Temp fix expired. Exiting."
-    else
-      pipx install --system-site-packages roadrecon
-      pipx inject roadrecon pyyaml numpy pandas
-    fi
+    pipx install --system-site-packages roadrecon
     add-test-command "roadrecon --help"
     add-test-command "roadrecon-gui --help"
     add-to-list "ROADrecon,https://github.com/dirkjanm/ROADtools#roadrecon,Azure AD recon for red and blue."

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1197,12 +1197,12 @@ function install_noPac() {
 function install_roadrecon() {
     # CODE-CHECK-WHITELIST=add-aliases,add-history
     colorecho "Installing roadrecon"
+    # pipx install --system-site-packages roadrecon[road2timeline]
     # Install dependencies of road2timeline plugin
     # see https://github.com/dirkjanm/ROADtools/pull/121
     local temp_fix_limit="2025-04-01"
     if [[ "$(date +%Y%m%d)" -gt "$(date -d $temp_fix_limit +%Y%m%d)" ]]; then
       criticalecho "Temp fix expired. Exiting."
-      pipx install --system-site-packages roadrecon[road2timeline]
     else
       pipx install --system-site-packages roadrecon
       pipx inject roadrecon pyyaml numpy pandas

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1205,8 +1205,10 @@ function install_roadrecon() {
 }
 
 function install_roadtx() {
+    # CODE-CHECK-WHITELIST=add-aliases,add-history
     colorecho "Installing roadtx"
     pipx install --system-site-packages roadtx
+    add-test-command "roadtx --help"
     add-to-list "ROADtx,https://github.com/dirkjanm/ROADtools#roadtools-token-exchange-roadtx,ROADtools Token eXchange."
 }
 

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1194,13 +1194,20 @@ function install_noPac() {
     add-to-list "noPac,https://github.com/Ridter/noPac,Exploiting CVE-2021-42278 and CVE-2021-42287 to impersonate DA from standard domain user."
 }
 
-function install_roadtools() {
+function install_roadrecon() {
     # CODE-CHECK-WHITELIST=add-aliases,add-history
-    colorecho "Installing roadtools"
+    colorecho "Installing roadrecon"
     pipx install --system-site-packages roadrecon
+    pipx inject roadrecon pyyaml numpy pandas # dependencies of road2timeline plugin
     add-test-command "roadrecon --help"
     add-test-command "roadrecon-gui --help"
-    add-to-list "ROADtools,https://github.com/dirkjanm/ROADtools,ROADtools is a framework to interact with Azure AD. It consists of a library (roadlib) with common components / the ROADrecon Azure AD exploration tool and the ROADtools Token eXchange (roadtx) tool."
+    add-to-list "ROADrecon,https://github.com/dirkjanm/ROADtools#roadrecon,Azure AD recon for red and blue."
+}
+
+function install_roadtx() {
+    colorecho "Installing roadtx"
+    pipx install --system-site-packages roadtx
+    add-to-list "ROADtx,https://github.com/dirkjanm/ROADtools#roadtools-token-exchange-roadtx,ROADtools Token eXchange."
 }
 
 function install_teamsphisher() {
@@ -1502,7 +1509,8 @@ function package_ad() {
     install_bqm                    # Deduplicate custom BloudHound queries from different datasets and merge them in one customqueries.json file.
     install_neo4j                  # Bloodhound dependency
     install_noPac
-    install_roadtools              # Rogue Office 365 and Azure (active) Directory tools
+    install_roadrecon              # Rogue Office 365 and Azure (active) Directory tools
+    install_roadtx                 # ROADtools Token eXchange
     install_teamsphisher           # TeamsPhisher is a Python3 program that facilitates the delivery of phishing messages and attachments to Microsoft Teams users whose organizations allow external communications.
     install_GPOddity
     install_netexec                # Crackmapexec repo

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1197,8 +1197,16 @@ function install_noPac() {
 function install_roadrecon() {
     # CODE-CHECK-WHITELIST=add-aliases,add-history
     colorecho "Installing roadrecon"
-    pipx install --system-site-packages roadrecon
-    pipx inject roadrecon pyyaml numpy pandas # dependencies of road2timeline plugin
+    # Install dependencies of road2timeline plugin
+    # see https://github.com/dirkjanm/ROADtools/pull/121
+    local temp_fix_limit="2025-04-01"
+    if [[ "$(date +%Y%m%d)" -gt "$(date -d $temp_fix_limit +%Y%m%d)" ]]; then
+      criticalecho "Temp fix expired. Exiting."
+      pipx install --system-site-packages roadrecon[road2timeline]
+    else
+      pipx install --system-site-packages roadrecon
+      pipx inject roadrecon pyyaml numpy pandas
+    fi
     add-test-command "roadrecon --help"
     add-test-command "roadrecon-gui --help"
     add-to-list "ROADrecon,https://github.com/dirkjanm/ROADtools#roadrecon,Azure AD recon for red and blue."


### PR DESCRIPTION
# Description

The project ROADtools actually consists of multiple packages. This renames ROADtools to roadrecon and adds roadtx (a tool to play with Azure Tokens)