### PR TITLE
Added a -p argument to the mkdir in the Cyberchef install

### DIFF
--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -167,7 +167,7 @@ function install_cyberchef() {
     if [[ -z "$last_release" ]]; then
         criticalecho-noexit "Latest release not found" && return
     fi
-    mkdir /opt/tools/CyberChef
+    mkdir -p /opt/tools/CyberChef
     wget "$last_release" -O /tmp/CyberChef.zip
     unzip -o /tmp/CyberChef.zip -d /opt/tools/CyberChef/
     rm /tmp/CyberChef.zip


### PR DESCRIPTION
# Description

When building the light image, the function `install_cyberchef` is ran twice because the light image run `package_most_used` AND `package_misc`. Thus if the `mkdir` call has not a `-p` argument, the image building fails because the directory already exist.

# Related issues

N / A

# Point of attention

N / A
