### PR TITLE
Call post_install for each docker layer.

### DIFF
--- a/.github/workflows/entrypoint_preprod_base.yml
+++ b/.github/workflows/entrypoint_preprod_base.yml
@@ -68,7 +68,6 @@ jobs:
               "sources/install/package_base.sh"
               "sources/install/entrypoint.sh"
               "sources/install/package_desktop.sh"
-              "sources/install/post_install.sh"
           )
           for file_to_check in "${files_to_check[@]}"; do
               if [[ $file_list =~ $file_to_check ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN ./entrypoint.sh package_steganography
 RUN ./entrypoint.sh package_reverse
 RUN ./entrypoint.sh package_crypto
 RUN ./entrypoint.sh package_code_analysis
+RUN ./entrypoint.sh post_build
 
 WORKDIR /workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-# WARNING: package_most_used can't be used with other functions other than: package_base, post_install
+# WARNING: package_most_used can't be used with other functions other than: package_base
 # ./entrypoint.sh package_most_used
 
 RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
@@ -45,7 +45,6 @@ RUN ./entrypoint.sh package_steganography
 RUN ./entrypoint.sh package_reverse
 RUN ./entrypoint.sh package_crypto
 RUN ./entrypoint.sh package_code_analysis
-RUN ./entrypoint.sh post_install
 
 WORKDIR /workspace
 

--- a/ad.dockerfile
+++ b/ad.dockerfile
@@ -32,6 +32,7 @@ RUN ./entrypoint.sh package_cracking
 RUN ./entrypoint.sh package_web
 RUN ./entrypoint.sh package_ad
 RUN ./entrypoint.sh package_network
+RUN ./entrypoint.sh post_build
 
 WORKDIR /workspace
 

--- a/ad.dockerfile
+++ b/ad.dockerfile
@@ -18,7 +18,7 @@ COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-# WARNING: package_most_used can't be used with other functions other than: package_base, post_install
+# WARNING: package_most_used can't be used with other functions other than: package_base
 # ./entrypoint.sh package_most_used
 
 RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
@@ -32,7 +32,6 @@ RUN ./entrypoint.sh package_cracking
 RUN ./entrypoint.sh package_web
 RUN ./entrypoint.sh package_ad
 RUN ./entrypoint.sh package_network
-RUN ./entrypoint.sh post_install
 
 WORKDIR /workspace
 

--- a/light.dockerfile
+++ b/light.dockerfile
@@ -27,6 +27,7 @@ RUN ./entrypoint.sh package_base
 RUN ./entrypoint.sh package_desktop
 RUN ./entrypoint.sh package_most_used
 RUN ./entrypoint.sh package_misc
+RUN ./entrypoint.sh post_build
 
 WORKDIR /workspace
 

--- a/light.dockerfile
+++ b/light.dockerfile
@@ -18,7 +18,7 @@ COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-# WARNING: package_most_used can't be used with other functions other than: package_base, post_install
+# WARNING: package_most_used can't be used with other functions other than: package_base
 # ./entrypoint.sh package_most_used
 
 RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
@@ -27,7 +27,6 @@ RUN ./entrypoint.sh package_base
 RUN ./entrypoint.sh package_desktop
 RUN ./entrypoint.sh package_most_used
 RUN ./entrypoint.sh package_misc
-RUN ./entrypoint.sh post_install
 
 WORKDIR /workspace
 

--- a/osint.dockerfile
+++ b/osint.dockerfile
@@ -27,6 +27,7 @@ RUN ./entrypoint.sh package_base
 RUN ./entrypoint.sh package_desktop
 RUN ./entrypoint.sh package_misc
 RUN ./entrypoint.sh package_osint
+RUN ./entrypoint.sh post_build
 
 WORKDIR /workspace
 

--- a/osint.dockerfile
+++ b/osint.dockerfile
@@ -18,7 +18,7 @@ COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-# WARNING: package_most_used can't be used with other functions other than: package_base, post_install
+# WARNING: package_most_used can't be used with other functions other than: package_base
 # ./entrypoint.sh package_most_used
 
 RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
@@ -27,7 +27,6 @@ RUN ./entrypoint.sh package_base
 RUN ./entrypoint.sh package_desktop
 RUN ./entrypoint.sh package_misc
 RUN ./entrypoint.sh package_osint
-RUN ./entrypoint.sh post_install
 
 WORKDIR /workspace
 

--- a/sources/dockerfiles/Dockerfile
+++ b/sources/dockerfiles/Dockerfile
@@ -21,7 +21,7 @@ COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-# WARNING: package_most_used can't be used with other functions other than: package_base, post_install
+# WARNING: package_most_used can't be used with other functions other than: package_base
 # ./entrypoint.sh package_most_used
 
 RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
@@ -47,7 +47,6 @@ RUN ./entrypoint.sh package_steganography
 RUN ./entrypoint.sh package_reverse
 RUN ./entrypoint.sh package_crypto
 RUN ./entrypoint.sh package_code_analysis
-RUN ./entrypoint.sh post_install
 
 WORKDIR /workspace
 

--- a/sources/dockerfiles/ad.dockerfile
+++ b/sources/dockerfiles/ad.dockerfile
@@ -21,7 +21,7 @@ COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-# WARNING: package_most_used can't be used with other functions other than: package_base, post_install
+# WARNING: package_most_used can't be used with other functions other than: package_base
 # ./entrypoint.sh package_most_used
 
 RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
@@ -34,7 +34,6 @@ RUN ./entrypoint.sh package_cracking
 RUN ./entrypoint.sh package_web
 RUN ./entrypoint.sh package_ad
 RUN ./entrypoint.sh package_network
-RUN ./entrypoint.sh post_install
 
 WORKDIR /workspace
 

--- a/sources/dockerfiles/base.dockerfile
+++ b/sources/dockerfiles/base.dockerfile
@@ -20,7 +20,6 @@ RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
 RUN chmod +x entrypoint.sh
 RUN ./entrypoint.sh package_base
 RUN ./entrypoint.sh package_desktop
-RUN ./entrypoint.sh post_install
 
 WORKDIR /workspace
 

--- a/sources/dockerfiles/light.dockerfile
+++ b/sources/dockerfiles/light.dockerfile
@@ -21,14 +21,13 @@ COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-# WARNING: package_most_used can't be used with other functions other than: package_base, post_install
+# WARNING: package_most_used can't be used with other functions other than: package_base
 # ./entrypoint.sh package_most_used
 
 RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
 RUN chmod +x entrypoint.sh
 RUN apt-get update
 RUN ./entrypoint.sh package_most_used
-RUN ./entrypoint.sh post_install
 
 WORKDIR /workspace
 

--- a/sources/dockerfiles/osint.dockerfile
+++ b/sources/dockerfiles/osint.dockerfile
@@ -21,7 +21,7 @@ COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-# WARNING: package_most_used can't be used with other functions other than: package_base, post_install
+# WARNING: package_most_used can't be used with other functions other than: package_base
 # ./entrypoint.sh package_most_used
 
 RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
@@ -29,7 +29,6 @@ RUN chmod +x entrypoint.sh
 RUN apt-get update
 RUN ./entrypoint.sh package_misc
 RUN ./entrypoint.sh package_osint
-RUN ./entrypoint.sh post_install
 
 WORKDIR /workspace
 

--- a/sources/dockerfiles/web.dockerfile
+++ b/sources/dockerfiles/web.dockerfile
@@ -21,7 +21,7 @@ COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-# WARNING: package_most_used can't be used with other functions other than: package_base, post_install
+# WARNING: package_most_used can't be used with other functions other than: package_base
 # ./entrypoint.sh package_most_used
 
 RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
@@ -33,7 +33,6 @@ RUN ./entrypoint.sh package_cracking
 RUN ./entrypoint.sh package_osint
 RUN ./entrypoint.sh package_web
 RUN ./entrypoint.sh package_code_analysis
-RUN ./entrypoint.sh post_install
 
 WORKDIR /workspace
 

--- a/sources/install/common.sh
+++ b/sources/install/common.sh
@@ -151,7 +151,6 @@ function post_install() {
     updatedb
     rm -rfv /tmp/*
     rm -rfv /var/lib/apt/lists/*
-    rm -rfv /root/sources
     rm -rfv /root/.cache
     rm -rfv /root/.gradle/caches
     colorecho "Stop listening processes"
@@ -163,6 +162,11 @@ function post_install() {
         # shellcheck disable=SC2086
         kill -9 $listening_processes
     fi
+}
+
+function post_build() {
+    colorecho "Post build..."
+    rm -rfv /root/sources
     add-test-command "if [[ $(sudo ss -lnpt | tail -n +2 | wc -l) -ne 0 ]]; then ss -lnpt && false;fi"
     colorecho "Sorting tools list"
     (head -n 1 /.exegol/installed_tools.csv && tail -n +2 /.exegol/installed_tools.csv | sort -f ) | tee /tmp/installed_tools.csv.sorted

--- a/sources/install/common.sh
+++ b/sources/install/common.sh
@@ -143,3 +143,34 @@ function define_retry_function() {
 for CMD in "${CATCH_AND_RETRY_COMMANDS[@]}"; do
   define_retry_function "$CMD"
 done
+
+function post_install() {
+    # Function used to clean up post-install files
+    colorecho "Cleaning..."
+    local listening_processes
+    updatedb
+    rm -rfv /tmp/*
+    rm -rfv /var/lib/apt/lists/*
+    rm -rfv /root/sources
+    rm -rfv /root/.cache
+    rm -rfv /root/.gradle/caches
+    colorecho "Stop listening processes"
+    listening_processes=$(ss -lnpt | awk -F"," 'NR>1 {split($2,a,"="); print a[2]}')
+    if [[ -n $listening_processes ]]; then
+        echo "Listening processes detected"
+        ss -lnpt
+        echo "Kill processes"
+        # shellcheck disable=SC2086
+        kill -9 $listening_processes
+    fi
+    add-test-command "if [[ $(sudo ss -lnpt | tail -n +2 | wc -l) -ne 0 ]]; then ss -lnpt && false;fi"
+    colorecho "Sorting tools list"
+    (head -n 1 /.exegol/installed_tools.csv && tail -n +2 /.exegol/installed_tools.csv | sort -f ) | tee /tmp/installed_tools.csv.sorted
+    mv /tmp/installed_tools.csv.sorted /.exegol/installed_tools.csv
+    colorecho "Adding end-of-preset in zsh_history"
+    echo "# -=-=-=-=-=-=-=- YOUR COMMANDS BELOW -=-=-=-=-=-=-=- #" >> /opt/.exegol_history
+    cp /opt/.exegol_history ~/.zsh_history
+    cp /opt/.exegol_history ~/.bash_history
+    colorecho "Removing desktop icons"
+    if [ -d "/root/Desktop" ]; then rm -r /root/Desktop; fi
+}

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1434,14 +1434,14 @@ function package_ad() {
     local end_time
     start_time=$(date +%s)
     install_ad_apt_tools
-    install_asrepcatcher           # Active Directory ASREP roasting tool that catches ASREP for users in the same VLAN whether they require pre-authentication or not
+    install_asrepcatcher            # Active Directory ASREP roasting tool that catches ASREP for users in the same VLAN whether they require pre-authentication or not
     install_pretender
     install_responder               # LLMNR, NBT-NS and MDNS poisoner
     install_ldapdomaindump
     install_sprayhound              # Password spraying tool
     install_smartbrute              # Password spraying tool
     install_bloodhound-py           # ingestor for legacy BloodHound
-    install_bloodhound-ce-py           # ingestor for legacy BloodHound
+    install_bloodhound-ce-py        # ingestor for legacy BloodHound
     install_bloodhound
     install_cypheroth               # Bloodhound dependency
     # install_mitm6_sources         # Install mitm6 from sources
@@ -1534,6 +1534,7 @@ function package_ad() {
     install_smbclientng
     install_conpass                # Python tool for continuous password spraying taking into account the password policy.
     install_adminer
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package ad completed in $elapsed_time seconds."

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1434,6 +1434,7 @@ function install_adminer() {
 
 # Package dedicated to internal Active Directory tools
 function package_ad() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -418,7 +418,6 @@ function install_asdf() {
 
 # Package dedicated to the basic things the env needs
 function package_base() {
-    set_env
     local start_time
     local end_time
     start_time=$(date +%s)

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -418,6 +418,10 @@ function install_asdf() {
 
 # Package dedicated to the basic things the env needs
 function package_base() {
+    set_env
+    local start_time
+    local end_time
+    start_time=$(date +%s)
     update
     colorecho "Installing apt-fast for faster dep installs"
     apt-get install -y curl sudo wget

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -390,37 +390,6 @@ function add_debian_repository_components() {
     mv "$out_file" "$source_file"
 }
 
-function post_install() {
-    # Function used to clean up post-install files
-    colorecho "Cleaning..."
-    local listening_processes
-    updatedb
-    rm -rfv /tmp/*
-    rm -rfv /var/lib/apt/lists/*
-    rm -rfv /root/sources
-    rm -rfv /root/.cache
-    rm -rfv /root/.gradle/caches
-    colorecho "Stop listening processes"
-    listening_processes=$(ss -lnpt | awk -F"," 'NR>1 {split($2,a,"="); print a[2]}')
-    if [[ -n $listening_processes ]]; then
-        echo "Listening processes detected"
-        ss -lnpt
-        echo "Kill processes"
-        # shellcheck disable=SC2086
-        kill -9 $listening_processes
-    fi
-    add-test-command "if [[ $(sudo ss -lnpt | tail -n +2 | wc -l) -ne 0 ]]; then ss -lnpt && false;fi"
-    colorecho "Sorting tools list"
-    (head -n 1 /.exegol/installed_tools.csv && tail -n +2 /.exegol/installed_tools.csv | sort -f ) | tee /tmp/installed_tools.csv.sorted
-    mv /tmp/installed_tools.csv.sorted /.exegol/installed_tools.csv
-    colorecho "Adding end-of-preset in zsh_history"
-    echo "# -=-=-=-=-=-=-=- YOUR COMMANDS BELOW -=-=-=-=-=-=-=- #" >> /opt/.exegol_history
-    cp /opt/.exegol_history ~/.zsh_history
-    cp /opt/.exegol_history ~/.bash_history
-    colorecho "Removing desktop icons"
-    if [ -d "/root/Desktop" ]; then rm -r /root/Desktop; fi
-}
-
 function install_asdf() {
     # CODE-CHECK-WHITELIST=add-aliases,add-history
     colorecho "Installing asdf"
@@ -575,4 +544,8 @@ function package_base() {
 
     # Global python dependencies
     pip3 install -r /root/sources/assets/python/requirements.txt
+    post_install
+    end_time=$(date +%s)
+    local elapsed_time=$((end_time - start_time))
+    colorecho "Package base completed in $elapsed_time seconds."
 }

--- a/sources/install/package_c2.sh
+++ b/sources/install/package_c2.sh
@@ -177,6 +177,7 @@ function install_villain() {
 
 # Package dedicated to command & control frameworks
 function package_c2() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_c2.sh
+++ b/sources/install/package_c2.sh
@@ -188,6 +188,7 @@ function package_c2() {
     install_sliver                  # Sliver is an open source cross-platform adversary emulation/red team framework
     install_havoc                   # C2 in Go
     install_villain                 # C2 using hoaxShell in Python
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package c2 completed in $elapsed_time seconds."

--- a/sources/install/package_cloud.sh
+++ b/sources/install/package_cloud.sh
@@ -130,6 +130,7 @@ function package_cloud() {
     install_prowler
     install_cloudmapper
     install_azure_cli       # Command line for Azure
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package cloud completed in $elapsed_time seconds."

--- a/sources/install/package_cloud.sh
+++ b/sources/install/package_cloud.sh
@@ -118,6 +118,7 @@ function install_azure_cli() {
 
 # Package dedicated to cloud tools
 function package_cloud() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_code_analysis.sh
+++ b/sources/install/package_code_analysis.sh
@@ -37,6 +37,7 @@ function install_pp-finder() {
 
 # Package dedicated to SAST and DAST tools
 function package_code_analysis() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_code_analysis.sh
+++ b/sources/install/package_code_analysis.sh
@@ -44,6 +44,7 @@ function package_code_analysis() {
     install_brakeman		            # Checks Ruby on Rails applications for security vulnerabilities
     install_semgrep                     # Static analysis engine for finding bugs and vulnerabilities
     install_pp-finder                   # Prototype pollution finder tool for javascript
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package code_analysis completed in $elapsed_time seconds."

--- a/sources/install/package_cracking.sh
+++ b/sources/install/package_cracking.sh
@@ -93,6 +93,7 @@ function package_cracking() {
     install_haiti                   # haiti, hash type identifier
     install_geowordlists            # wordlists generator
     install_pkcrack                 # known plaintext ZIP cracker
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package cracking completed in $elapsed_time seconds."

--- a/sources/install/package_cracking.sh
+++ b/sources/install/package_cracking.sh
@@ -83,6 +83,7 @@ function install_pkcrack() {
 
 # Package dedicated to offline cracking/bruteforcing tools
 function package_cracking() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_crypto.sh
+++ b/sources/install/package_crypto.sh
@@ -49,6 +49,7 @@ function package_crypto() {
     install_rsactftool              # attack rsa
     install_tls-map                 # CLI & library for mapping TLS cipher algorithm names: IANA, OpenSSL, GnuTLS, NSS
     install_rsacracker              # Powerful RSA cracker for CTFs. Supports RSA, X509, OPENSSH in PEM and DER formats.
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package crypto completed in $elapsed_time seconds."

--- a/sources/install/package_crypto.sh
+++ b/sources/install/package_crypto.sh
@@ -42,6 +42,7 @@ function install_rsacracker() {
 
 # Package dedicated to attack crypto
 function package_crypto() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_desktop.sh
+++ b/sources/install/package_desktop.sh
@@ -113,4 +113,8 @@ function install_xfce() {
 
 function package_desktop() {
     install_xfce
+    post_install
+    end_time=$(date +%s)
+    local elapsed_time=$((end_time - start_time))
+    colorecho "Package desktop completed in $elapsed_time seconds."
 }

--- a/sources/install/package_desktop.sh
+++ b/sources/install/package_desktop.sh
@@ -112,6 +112,7 @@ function install_xfce() {
 }
 
 function package_desktop() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_desktop.sh
+++ b/sources/install/package_desktop.sh
@@ -112,6 +112,10 @@ function install_xfce() {
 }
 
 function package_desktop() {
+    set_env
+    local start_time
+    local end_time
+    start_time=$(date +%s)
     install_xfce
     post_install
     end_time=$(date +%s)

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -128,6 +128,7 @@ function package_forensic() {
     install_peepdf                  # PDF analysis
     install_jadx                    # Dex to Java decompiler
     install_chainsaw                # Rapidly Search and Hunt through Windows Forensic Artefacts
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package forensic completed in $elapsed_time seconds."

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -116,6 +116,7 @@ function install_chainsaw() {
 
 # Package dedicated to forensic tools
 function package_forensic() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_iot.sh
+++ b/sources/install/package_iot.sh
@@ -25,6 +25,7 @@ function package_iot() {
     local end_time
     start_time=$(date +%s)
     install_iot_apt_tools
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package iot completed in $elapsed_time seconds."

--- a/sources/install/package_iot.sh
+++ b/sources/install/package_iot.sh
@@ -20,6 +20,7 @@ function install_iot_apt_tools() {
 
 # Package dedicated to IoT tools
 function package_iot() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -213,6 +213,7 @@ function install_wesng() {
 
 # Package dedicated to offensive miscellaneous tools
 function package_misc() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -233,6 +233,7 @@ function package_misc() {
     install_creds           # A default credentials vault
     install_uploader        # uploader for fast file upload
     install_wesng           # Search Windows vulnerability via systeminfo
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package misc completed in $elapsed_time seconds."

--- a/sources/install/package_mobile.sh
+++ b/sources/install/package_mobile.sh
@@ -128,6 +128,7 @@ function package_mobile() {
     install_objection               # Runtime mobile exploration toolkit
     install_androguard              # Reverse engineering and analysis of Android applications
     install_mobsf                   # Automated mobile application testing framework
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package mobile completed in $elapsed_time seconds."

--- a/sources/install/package_mobile.sh
+++ b/sources/install/package_mobile.sh
@@ -116,6 +116,7 @@ function install_mobsf() {
 
 # Package dedicated to mobile apps pentest tools
 function package_mobile() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_most_used.sh
+++ b/sources/install/package_most_used.sh
@@ -47,6 +47,7 @@ function install_most_used_apt_tools() {
 
 # Package dedicated to most used offensive tools
 function package_most_used() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_most_used.sh
+++ b/sources/install/package_most_used.sh
@@ -84,6 +84,11 @@ function package_most_used() {
     install_netexec                 # Crackmapexec repo
     install_sslscan                 # SSL/TLS scanner
     install_cyberchef               # A web based toolbox
+    install_neo4j
+    install_bloodhound
+    install_bloodhound-py           # Ingestor for legacy BloodHound
+    install_coercer                 # Python script to coerce auth through multiple methods
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package most_used completed in $elapsed_time seconds."

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -325,6 +325,7 @@ function package_network() {
     install_rustscan
     install_legba                   # Login Scanner
     install_ssh-audit               # SSH server audit
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package network completed in $elapsed_time seconds."

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -300,6 +300,7 @@ function install_ssh-audit() {
 
 # Package dedicated to network pentest tools
 function package_network() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_osint.sh
+++ b/sources/install/package_osint.sh
@@ -574,6 +574,7 @@ function package_osint() {
     install_censys                  # An easy-to-use and lightweight API wrapper for Censys APIs
     install_gomapenum               # Nothing new but existing techniques are brought together in one tool.
     install_pymeta
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package osint completed in $elapsed_time seconds."

--- a/sources/install/package_osint.sh
+++ b/sources/install/package_osint.sh
@@ -527,6 +527,7 @@ function install_pymeta() {
 
 # Package dedicated to osint, recon and passive tools
 function package_osint() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_reverse.sh
+++ b/sources/install/package_reverse.sh
@@ -146,6 +146,7 @@ function install_pwninit() {
 
 # Package dedicated to reverse engineering tools
 function package_reverse() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_reverse.sh
+++ b/sources/install/package_reverse.sh
@@ -160,6 +160,7 @@ function package_reverse() {
     install_ida
     install_jd-gui                  # Java decompiler
     install_pwninit                 # Tool for automating starting binary exploit
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package reverse completed in $elapsed_time seconds."

--- a/sources/install/package_rfid.sh
+++ b/sources/install/package_rfid.sh
@@ -89,6 +89,7 @@ function install_proxmark3() {
 
 # Package dedicated to RFID/NCF pentest tools
 function package_rfid() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_rfid.sh
+++ b/sources/install/package_rfid.sh
@@ -98,6 +98,7 @@ function package_rfid() {
     install_libnfc-crypto1-crack    # tool for hardnested attack on Mifare Classic
     install_mfdread                 # Tool to pretty print Mifare 1k/4k dumps
     install_proxmark3               # Proxmark3 scripts
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package rfid completed in $elapsed_time seconds."

--- a/sources/install/package_sdr.sh
+++ b/sources/install/package_sdr.sh
@@ -57,6 +57,7 @@ function package_sdr() {
     install_sdr_apt_tools
     install_mousejack               # tools for mousejacking
     install_jackit                  # tools for mousejacking
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package sdr completed in $elapsed_time seconds."

--- a/sources/install/package_sdr.sh
+++ b/sources/install/package_sdr.sh
@@ -50,6 +50,7 @@ function install_jackit() {
 
 # Package dedicated to SDR
 function package_sdr() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_steganography.sh
+++ b/sources/install/package_steganography.sh
@@ -57,6 +57,7 @@ function package_steganography() {
     install_steganography_apt_tools
     install_zsteg                   # Detect stegano-hidden data in PNG & BMP
     install_stegolsb                # (including wavsteg)
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package steganography completed in $elapsed_time seconds."

--- a/sources/install/package_steganography.sh
+++ b/sources/install/package_steganography.sh
@@ -50,6 +50,7 @@ function install_stegolsb() {
 
 # Package dedicated to steganography tools
 function package_steganography() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_voip.sh
+++ b/sources/install/package_voip.sh
@@ -19,6 +19,7 @@ function package_voip() {
     local end_time
     start_time=$(date +%s)
     install_sipvicious              # Set of tools for auditing SIP based VOIP systems
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package voip completed in $elapsed_time seconds."

--- a/sources/install/package_voip.sh
+++ b/sources/install/package_voip.sh
@@ -14,6 +14,7 @@ function install_sipvicious() {
 
 # Package dedicated to VOIP/SIP pentest tools
 function package_voip() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -921,6 +921,7 @@ function install_token_exploiter() {
 
 # Package dedicated to applicative and active web pentest tools
 function package_web() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -1000,6 +1000,7 @@ function package_web() {
     install_postman                 # Postman - API platform for testing APIs
     install_zap                     # Zed Attack Proxy
     install_token_exploiter         # Github personal token Analyzer
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package web completed in $elapsed_time seconds."

--- a/sources/install/package_wifi.sh
+++ b/sources/install/package_wifi.sh
@@ -129,6 +129,7 @@ function package_wifi() {
     install_bettercap               # MiTM tool
     install_hcxtools                # Tools for PMKID and other wifi attacks
     install_hcxdumptool             # Small tool to capture packets from wlan devices
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package wifi completed in $elapsed_time seconds."

--- a/sources/install/package_wifi.sh
+++ b/sources/install/package_wifi.sh
@@ -118,6 +118,7 @@ function install_hcxdumptool() {
 
 # Package dedicated to wifi pentest tools
 function package_wifi() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_wordlists.sh
+++ b/sources/install/package_wordlists.sh
@@ -96,6 +96,7 @@ function install_genusernames() {
 
 # Package dedicated to the installation of wordlists and tools like wl generators
 function package_wordlists() {
+    apt-get update
     set_env
     local start_time
     local end_time

--- a/sources/install/package_wordlists.sh
+++ b/sources/install/package_wordlists.sh
@@ -107,6 +107,7 @@ function package_wordlists() {
     install_pass_station            # Default credentials database
     install_username-anarchy        # Generate possible usernames based on heuristics
     install_genusernames
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package wordlists completed in $elapsed_time seconds."

--- a/web.dockerfile
+++ b/web.dockerfile
@@ -18,7 +18,7 @@ COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-# WARNING: package_most_used can't be used with other functions other than: package_base, post_install
+# WARNING: package_most_used can't be used with other functions other than: package_base
 # ./entrypoint.sh package_most_used
 
 RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
@@ -31,7 +31,6 @@ RUN ./entrypoint.sh package_cracking
 RUN ./entrypoint.sh package_osint
 RUN ./entrypoint.sh package_web
 RUN ./entrypoint.sh package_code_analysis
-RUN ./entrypoint.sh post_install
 
 WORKDIR /workspace
 

--- a/web.dockerfile
+++ b/web.dockerfile
@@ -31,6 +31,7 @@ RUN ./entrypoint.sh package_cracking
 RUN ./entrypoint.sh package_osint
 RUN ./entrypoint.sh package_web
 RUN ./entrypoint.sh package_code_analysis
+RUN ./entrypoint.sh post_build
 
 WORKDIR /workspace
 

--- a/wifi.dockerfile
+++ b/wifi.dockerfile
@@ -29,6 +29,7 @@ RUN ./entrypoint.sh package_misc
 RUN ./entrypoint.sh package_wordlists
 RUN ./entrypoint.sh package_cracking
 RUN ./entrypoint.sh package_wifi
+RUN ./entrypoint.sh post_build
 
 WORKDIR /workspace
 

--- a/wifi.dockerfile
+++ b/wifi.dockerfile
@@ -18,7 +18,7 @@ COPY sources /root/sources/
 
 WORKDIR /root/sources/install
 
-# WARNING: package_most_used can't be used with other functions other than: package_base, post_install
+# WARNING: package_most_used can't be used with other functions other than: package_base
 # ./entrypoint.sh package_most_used
 
 RUN echo "${TAG}-${VERSION}" > /opt/.exegol_version
@@ -29,7 +29,6 @@ RUN ./entrypoint.sh package_misc
 RUN ./entrypoint.sh package_wordlists
 RUN ./entrypoint.sh package_cracking
 RUN ./entrypoint.sh package_wifi
-RUN ./entrypoint.sh post_install
 
 WORKDIR /workspace
 


### PR DESCRIPTION
# Description

This PR calls the `post_install` function for each Docker layer, allowing for cache cleaning and removal of unnecessary files after each layer is installed.

Here is an example: This `Dockerfile` uses 2 `RUN` commands (**2 layers**). The first one creates a file, and the second one deletes it. In this case, the first layer will still contain the file, even if it is deleted in the final image.

**test1 :**

```bash
FROM debian:12

RUN echo 'hello' > /root/hello.txt
RUN rm /root/hello.txt

CMD ["bash"]
```

In the second example, the file is created and cleaned up within the same `RUN` command (**same layer**). As a result, this approach saves space.

By combining commands within a single layer, we avoid persisting unnecessary files in the Docker image history.

**test2 :**

```bash
FROM debian:12

RUN echo 'hello' > /root/hello.txt && rm /root/hello.txt

CMD ["bash"]
```

```bash
-rw-------@ 1 qu35t  wheel  143617024 Feb 27 11:26 test1.tar.gz
-rw-------@ 1 qu35t  wheel  143610880 Feb 27 11:27 test2.tar.gz
```

# Related issues

* ThePorgs/Development#237