### PR TITLE
fix: curl never ever retried + reduce verbose

### DIFF
--- a/sources/assets/shells/.curlrc
+++ b/sources/assets/shells/.curlrc
@@ -1,0 +1,7 @@
+# This file should be named `.curlrc` because curl will search for a "$CURL_HOME/.curlrc" file (defined in common.sh).
+# See <https://curl.se/docs/manpage.html#-K> for more information.
+
+# Fail silently (no output at all) on HTTP errors. See <https://curl.se/docs/manpage.html#-f>
+--fail
+# As --fail makes curl fail silently, this parameter will show an error message anyway. See <https://curl.se/docs/manpage.html#-S>
+--show-error

--- a/sources/assets/shells/wgetrc
+++ b/sources/assets/shells/wgetrc
@@ -1,0 +1,3 @@
+# Wget config only used in build stage (defined in common.sh)
+# The following option prevent wget from generating too much output
+progress=dot:mega

--- a/sources/install/common.sh
+++ b/sources/install/common.sh
@@ -86,8 +86,12 @@ function set_asdf_env(){
 }
 
 function set_build_only_env(){
+    # Here you can set environment variables that are only needed during the build process
     colorecho "Setting build only environment"
-    export CURL_HOME="/root/sources/assets/shells/"
+    
+    # Make curl fails on HTTP errors (4xx and 5xx) because it doesn't by default
+    export CURL_HOME="/root/sources/assets/shells/" # Curl will search for .curlrc in this directory
+    # Make wget a bit less verbose
     export WGETRC="/root/sources/assets/shells/wgetrc"
 }
 

--- a/sources/install/common.sh
+++ b/sources/install/common.sh
@@ -85,6 +85,11 @@ function set_asdf_env(){
     export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 }
 
+function set_build_only_env(){
+    colorecho "Setting build only environment"
+    export WGETRC="/root/sources/assets/shells/wgetrc"
+}
+
 function set_env() {
     colorecho "Setting env (caller)"
     set_bin_path
@@ -92,6 +97,7 @@ function set_env() {
     set_ruby_env
     set_python_env
     set_asdf_env
+    set_build_only_env
 }
 
 ### Catch & retry definitions

--- a/sources/install/common.sh
+++ b/sources/install/common.sh
@@ -87,6 +87,7 @@ function set_asdf_env(){
 
 function set_build_only_env(){
     colorecho "Setting build only environment"
+    export CURL_HOME="/root/sources/assets/shells/"
     export WGETRC="/root/sources/assets/shells/wgetrc"
 }
 

--- a/sources/install/package_cloud.sh
+++ b/sources/install/package_cloud.sh
@@ -40,7 +40,7 @@ function install_awscli() {
     else
         criticalecho-noexit "This installation function doesn't support architecture $(uname -m)" && return
     fi
-    unzip awscliv2.zip
+    unzip -q awscliv2.zip # -q because too much useless verbose
     ./aws/install -i /opt/tools/aws-cli -b /usr/local/bin
     rm -rf aws
     rm awscliv2.zip

--- a/sources/install/package_reverse.sh
+++ b/sources/install/package_reverse.sh
@@ -95,7 +95,7 @@ function install_ghidra() {
     # CODE-CHECK-WHITELIST=add-test-command
     colorecho "Installing Ghidra"
     wget -P /tmp/ "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.1.2_build/ghidra_10.1.2_PUBLIC_20220125.zip"
-    unzip /tmp/ghidra_10.1.2_PUBLIC_20220125.zip -d /opt/tools
+    unzip -q /tmp/ghidra_10.1.2_PUBLIC_20220125.zip -d /opt/tools # -q because too much useless verbose
     rm /tmp/ghidra_10.1.2_PUBLIC_20220125.zip
     add-aliases ghidra
     add-history ghidra


### PR DESCRIPTION
# Fix curl

#458 fails first because of `upx`, and now because of `BloodHound` because curl never ever retried when guthub is rate-limited, here my fix using a `.curlrc` to make it globally available :)

## BloodHound-CE

Before:
```
[EXEGOL] Installing BloodHound-CE
[SNIP...]
[EXEGOL] Catch & retry function for: curl
[EXEGOL DEBUG] sh -c "curl --location --silent https://api.github.com/repos/SpecterOps/BloodHound/releases -o /tmp/tmp.84z9GSOOkf "
jq: error (at /tmp/tmp.84z9GSOOkf:1): Cannot index string with string "tag_name"
The command '/bin/sh -c ./entrypoint.sh ${FUNCTION}' returned a non-zero code: 5
```

After:
```
[EXEGOL] Installing BloodHound-CE
[SNIP...]
[EXEGOL] Catch & retry function for: curl
[EXEGOL DEBUG] sh -c "curl --location --silent https://api.github.com/repos/SpecterOps/BloodHound/releases -o /tmp/tmp.e1UUs2KLjQ "
curl: (22) The requested URL returned error: 403
[EXEGOL ERROR] Command failed (attempt 1/5). Retrying in 8 seconds...
[EXEGOL DEBUG] sh -c "curl --location --silent https://api.github.com/repos/SpecterOps/BloodHound/releases -o /tmp/tmp.e1UUs2KLjQ "
curl: (22) The requested URL returned error: 403
[EXEGOL ERROR] Command failed (attempt 2/5). Retrying in 32 seconds...
[EXEGOL DEBUG] sh -c "curl --location --silent https://api.github.com/repos/SpecterOps/BloodHound/releases -o /tmp/tmp.e1UUs2KLjQ "
curl: (22) The requested URL returned error: 403
[EXEGOL ERROR] Command failed (attempt 3/5). Retrying in 128 seconds...
```

## UPX

Before
```
[EXEGOL] Installing upx
The command '/bin/sh -c ./entrypoint.sh ${FUNCTION}' returned a non-zero code: 1
```

After
```
[EXEGOL] Installing upx
[EXEGOL] Catch & retry function for: curl
[EXEGOL DEBUG] sh -c "curl --location --silent https://api.github.com/repos/upx/upx/releases/latest -o /tmp/tmp.T9M2owIVjS "
curl: (22) The requested URL returned error: 403
[EXEGOL ERROR] Command failed (attempt 1/5). Retrying in 8 seconds...
[EXEGOL DEBUG] sh -c "curl --location --silent https://api.github.com/repos/upx/upx/releases/latest -o /tmp/tmp.T9M2owIVjS "
curl: (22) The requested URL returned error: 403
[EXEGOL ERROR] Command failed (attempt 2/5). Retrying in 32 seconds...
[EXEGOL DEBUG] sh -c "curl --location --silent https://api.github.com/repos/upx/upx/releases/latest -o /tmp/tmp.T9M2owIVjS "
curl: (22) The requested URL returned error: 403
[EXEGOL ERROR] Command failed (attempt 3/5). Retrying in 128 seconds...
```

# Reduce verbose

16% of logs are wget verbose, I just reduced it by 64 using `--progress=dot:mega`, only during installation. (See [wget/index-progress-indicator](https://www.gnu.org/software/wget/manual/wget.html#index-progress-indicator))

> [Does running commands verbosely make them slower?](https://superuser.com/questions/312877/does-running-commands-verbosely-make-them-slower)
> TLDR: Yes, running verbose will slow down your applications.

```shell
$ wc -l logs 
226302 logs
$ grep ".......... .......... .......... .......... .........." logs | wc -l
36838
```

5% of logs are aws and ghidra unzip logs, I made them a bit more quiet
```shell
$ grep "aws/dist" logs | wc -l
8541
$ grep "/opt/tools/ghidra_10.1.2_PUBLIC" logs | wc -l
4289
```