### PR TITLE
Using higher Go version for bettercap install

### DIFF
--- a/sources/assets/shells/aliases.d/bettercap
+++ b/sources/assets/shells/aliases.d/bettercap
@@ -1,1 +1,2 @@
+alias bettercap="/opt/tools/bettercap/.go/bin/bettercap"
 alias bettercap-ui='bettercap -caplet http-ui'

--- a/sources/install/package_wifi.sh
+++ b/sources/install/package_wifi.sh
@@ -78,7 +78,7 @@ function install_bettercap() {
     fapt libpcap-dev libusb-1.0-0-dev libnetfilter-queue-dev
     mkdir -p /opt/tools/bettercap || exit
     cd /opt/tools/bettercap || exit
-    # Custom install because it require go >= 1.23.0 (default running go is 1.22.2)
+    # Custom install because it requires go >= 1.23.0 (default running go is 1.22.2)
     asdf set golang 1.23.0
     mkdir -p .go/bin
     GOBIN=/opt/tools/bettercap/.go/bin go install -v github.com/bettercap/bettercap@latest

--- a/sources/install/package_wifi.sh
+++ b/sources/install/package_wifi.sh
@@ -76,9 +76,13 @@ function install_wifite2() {
 function install_bettercap() {
     colorecho "Installing Bettercap"
     fapt libpcap-dev libusb-1.0-0-dev libnetfilter-queue-dev
-    go install -v github.com/bettercap/bettercap@latest
-    asdf reshim golang
-    bettercap -eval "caplets.update; ui.update; q"
+    mkdir -p /opt/tools/bettercap || exit
+    cd /opt/tools/bettercap || exit
+    # Custom install because it require go >= 1.23.0 (default running go is 1.22.2)
+    asdf set golang 1.23.0
+    mkdir -p .go/bin
+    GOBIN=/opt/tools/bettercap/.go/bin go install -v github.com/bettercap/bettercap@latest
+    /opt/tools/bettercap/.go/bin/bettercap -eval "caplets.update; ui.update; q"
     sed -i 's/set api.rest.username user/set api.rest.username bettercap/g' /usr/local/share/bettercap/caplets/http-ui.cap
     sed -i 's/set api.rest.password pass/set api.rest.password exegol4thewin/g' /usr/local/share/bettercap/caplets/http-ui.cap
     sed -i 's/set api.rest.username user/set api.rest.username bettercap/g' /usr/local/share/bettercap/caplets/https-ui.cap


### PR DESCRIPTION
I was inspired by what was done for ruler:
https://github.com/ThePorgs/Exegol-images/blob/7d7bf085cc86eb9e03f0cb0a3007045a4647d2ff/sources/install/package_ad.sh#L341-L346

![image](https://github.com/user-attachments/assets/4c9407d4-1908-47e3-9439-f80eb2dc257d)
