### PR TITLE
Increasing the timeout threshold

### DIFF
--- a/sources/assets/exegol/build_pipeline_tests/run_tests.py
+++ b/sources/assets/exegol/build_pipeline_tests/run_tests.py
@@ -30,7 +30,7 @@ YELLOW = "\033[33m"
 RESET = "\033[0m"
 
 # Configuration constants
-COMMAND_TIMEOUT = 20
+COMMAND_TIMEOUT = 30
 CONCURRENT_TASKS = 5
 
 class CommandRunner:


### PR DESCRIPTION
Because the #464' `zap -suppinfo` test has timed out [here](https://github.com/ThePorgs/Exegol-images/actions/runs/13739604811/job/38430191880?pr=464#step:4:447).

In fact, this test (and zed) is really slow: 15 seconds on my computer (which I consider quite powerful):
```
[Mar 08, 2025 - 21:31:29 (UTC)] 3738b929bf54 /workspace # time zap -suppinfo
[SNIP...]
real	0m15.686s
user	0m17.295s
sys	0m1.243s
[Mar 08, 2025 - 21:32:40 (UTC)] 3738b929bf54 /workspace # time zap -help
[SNIP...]
real	0m14.413s
user	0m18.187s
sys	0m0.943s
```

This test, which is already slow, combined with other tests running in parallel, could fail the pipeline even though it's just slow (like the example I mentioned above). I think it would be a good idea to slightly increase the timeout threshold and avoid wasting a pipeline because of this silly mishap.