### PR TITLE
Fixed optional dependencies for volatility3

### DIFF
--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -57,6 +57,8 @@ function install_volatility2() {
 function install_volatility3() {
     colorecho "Installing volatility3"
     pipx install --system-site-packages git+https://github.com/volatilityfoundation/volatility3
+    # https://github.com/volatilityfoundation/volatility3/blob/bd5fb7d61148afef031faade3efe68dcb012d95a/pyproject.toml#L23
+    pipx inject volatility3 "yara-python>=4.5.1,<5" "capstone>=5.0.3,<6" "pycryptodome>=3.21.0,<4" "leechcorepyc>=2.19.2,<3; sys_platform != 'darwin'" "pillow>=10.0.0,<11.0.0"
     add-aliases volatility3
     add-history volatility3
     add-test-command "volatility3 --help"

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -57,8 +57,9 @@ function install_volatility2() {
 function install_volatility3() {
     colorecho "Installing volatility3"
     pipx install --system-site-packages git+https://github.com/volatilityfoundation/volatility3
+    # We are using the full path of 'pipx', because otherwise our catch and retry mechanism mess with the command
     # https://github.com/volatilityfoundation/volatility3/blob/bd5fb7d61148afef031faade3efe68dcb012d95a/pyproject.toml#L23
-    pipx inject volatility3 'yara-python>=4.5.1,<5' 'capstone>=5.0.3,<6' 'pycryptodome>=3.21.0,<4' 'leechcorepyc>=2.19.2,<3; sys_platform != "darwin"' 'pillow>=10.0.0,<11.0.0'
+    /root/.pyenv/shims/pipx inject volatility3 'yara-python>=4.5.1,<5' 'capstone>=5.0.3,<6' 'pycryptodome>=3.21.0,<4' 'leechcorepyc>=2.19.2,<3; sys_platform != "darwin"' 'pillow>=10.0.0,<11.0.0'
     add-aliases volatility3
     add-history volatility3
     add-test-command "volatility3 --help"

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -58,7 +58,7 @@ function install_volatility3() {
     colorecho "Installing volatility3"
     pipx install --system-site-packages git+https://github.com/volatilityfoundation/volatility3
     # https://github.com/volatilityfoundation/volatility3/blob/bd5fb7d61148afef031faade3efe68dcb012d95a/pyproject.toml#L23
-    pipx inject volatility3 "yara-python>=4.5.1,<5" "capstone>=5.0.3,<6" "pycryptodome>=3.21.0,<4" "leechcorepyc>=2.19.2,<3; sys_platform != 'darwin'" "pillow>=10.0.0,<11.0.0"
+    pipx inject volatility3 'yara-python>=4.5.1,<5' 'capstone>=5.0.3,<6' 'pycryptodome>=3.21.0,<4' 'leechcorepyc>=2.19.2,<3; sys_platform != "darwin"' 'pillow>=10.0.0,<11.0.0'
     add-aliases volatility3
     add-history volatility3
     add-test-command "volatility3 --help"


### PR DESCRIPTION
# Description

Running `volatility3 -vv` show that some modules cannot be used because the dependecies are not installed:
```
Volatility 3 Framework 2.24.0
INFO     volatility3.cli: Volatility plugins path: ['/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/plugins', '/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins']
INFO     volatility3.cli: Volatility symbols path: ['/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/symbols', '/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/symbols']
INFO     volatility3.plugins.yarascan: Neither yara-x nor yara-python (>3.8.0) module not found, plugin (and dependent plugins) not available
DEBUG    volatility3.framework: Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py", line 19, in <module>
    import yara_x
ModuleNotFoundError: No module named 'yara_x'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/__init__.py", line 173, in import_file
    importlib.import_module(module)
  File "/root/.pyenv/versions/3.11.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py", line 25, in <module>
    import yara
ModuleNotFoundError: No module named 'yara'
DEBUG    volatility3.framework: Failed to import module volatility3.plugins.yarascan based on file: /root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py
INFO     volatility3.plugins.yarascan: Neither yara-x nor yara-python (>3.8.0) module not found, plugin (and dependent plugins) not available
DEBUG    volatility3.framework: Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py", line 19, in <module>
    import yara_x
ModuleNotFoundError: No module named 'yara_x'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/__init__.py", line 173, in import_file
    importlib.import_module(module)
  File "/root/.pyenv/versions/3.11.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/linux/vmayarascan.py", line 11, in <module>
    from volatility3.plugins import yarascan
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py", line 25, in <module>
    import yara
ModuleNotFoundError: No module named 'yara'
DEBUG    volatility3.framework: Failed to import module volatility3.plugins.linux.vmayarascan based on file: /root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/linux/vmayarascan.py
INFO     volatility3.plugins.yarascan: Neither yara-x nor yara-python (>3.8.0) module not found, plugin (and dependent plugins) not available
DEBUG    volatility3.framework: Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py", line 19, in <module>
    import yara_x
ModuleNotFoundError: No module named 'yara_x'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/__init__.py", line 173, in import_file
    importlib.import_module(module)
  File "/root/.pyenv/versions/3.11.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/vadyarascan.py", line 11, in <module>
    from volatility3.plugins import yarascan
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py", line 25, in <module>
    import yara
ModuleNotFoundError: No module named 'yara'
DEBUG    volatility3.framework: Failed to import module volatility3.plugins.windows.vadyarascan based on file: /root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/vadyarascan.py
DEBUG    volatility3.framework: Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/__init__.py", line 173, in import_file
    importlib.import_module(module)
  File "/root/.pyenv/versions/3.11.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/hashdump.py", line 10, in <module>
    from Crypto.Cipher import AES, ARC4, DES
ModuleNotFoundError: No module named 'Crypto'
DEBUG    volatility3.framework: Failed to import module volatility3.plugins.windows.hashdump based on file: /root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/hashdump.py
INFO     volatility3.plugins.yarascan: Neither yara-x nor yara-python (>3.8.0) module not found, plugin (and dependent plugins) not available
DEBUG    volatility3.framework: Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py", line 19, in <module>
    import yara_x
ModuleNotFoundError: No module named 'yara_x'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/__init__.py", line 173, in import_file
    importlib.import_module(module)
  File "/root/.pyenv/versions/3.11.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/mftscan.py", line 15, in <module>
    from volatility3.plugins import timeliner, yarascan
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py", line 25, in <module>
    import yara
ModuleNotFoundError: No module named 'yara'
DEBUG    volatility3.framework: Failed to import module volatility3.plugins.windows.mftscan based on file: /root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/mftscan.py
INFO     volatility3.plugins.yarascan: Neither yara-x nor yara-python (>3.8.0) module not found, plugin (and dependent plugins) not available
DEBUG    volatility3.framework: Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py", line 19, in <module>
    import yara_x
ModuleNotFoundError: No module named 'yara_x'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/__init__.py", line 173, in import_file
    importlib.import_module(module)
  File "/root/.pyenv/versions/3.11.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/indirect_system_calls.py", line 11, in <module>
    from volatility3.plugins import yarascan
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py", line 25, in <module>
    import yara
ModuleNotFoundError: No module named 'yara'
DEBUG    volatility3.framework: Failed to import module volatility3.plugins.windows.indirect_system_calls based on file: /root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/indirect_system_calls.py
INFO     volatility3.plugins.yarascan: Neither yara-x nor yara-python (>3.8.0) module not found, plugin (and dependent plugins) not available
DEBUG    volatility3.framework: Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py", line 19, in <module>
    import yara_x
ModuleNotFoundError: No module named 'yara_x'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/__init__.py", line 173, in import_file
    importlib.import_module(module)
  File "/root/.pyenv/versions/3.11.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/direct_system_calls.py", line 13, in <module>
    from volatility3.plugins import yarascan
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/yarascan.py", line 25, in <module>
    import yara
ModuleNotFoundError: No module named 'yara'
DEBUG    volatility3.framework: Failed to import module volatility3.plugins.windows.direct_system_calls based on file: /root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/direct_system_calls.py
DEBUG    volatility3.framework: Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/__init__.py", line 173, in import_file
    importlib.import_module(module)
  File "/root/.pyenv/versions/3.11.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/cachedump.py", line 8, in <module>
    from Crypto.Cipher import ARC4, AES
ModuleNotFoundError: No module named 'Crypto'
DEBUG    volatility3.framework: Failed to import module volatility3.plugins.windows.cachedump based on file: /root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/cachedump.py
DEBUG    volatility3.framework: Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/__init__.py", line 173, in import_file
    importlib.import_module(module)
  File "/root/.pyenv/versions/3.11.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/lsadump.py", line 9, in <module>
    from Crypto.Cipher import ARC4, DES, AES
ModuleNotFoundError: No module named 'Crypto'
DEBUG    volatility3.framework: Failed to import module volatility3.plugins.windows.lsadump based on file: /root/.local/share/pipx/venvs/volatility3/lib/python3.11/site-packages/volatility3/framework/plugins/windows/lsadump.py
INFO     volatility3.cli: The following plugins could not be loaded (use -vv to see why): volatility3.plugins.linux.vmayarascan, volatility3.plugins.windows.cachedump, volatility3.plugins.windows.direct_system_calls, volatility3.plugins.windows.hashdump, volatility3.plugins.windows.indirect_system_calls, volatility3.plugins.windows.lsadump, volatility3.plugins.windows.mftscan, volatility3.plugins.windows.vadyarascan, volatility3.plugins.yarascan
usage: vol [-h] [-c CONFIG] [--parallelism [{processes,threads,off}]] [-e EXTEND] [-p PLUGIN_DIRS] [-s SYMBOL_DIRS] [-v] [-l LOG]
           [-o OUTPUT_DIR] [-q] [-r RENDERER] [-f FILE] [--write-config] [--save-config SAVE_CONFIG] [--clear-cache]
           [--cache-path CACHE_PATH] [--offline | -u URL] [--filters FILTERS] [--hide-columns [HIDE_COLUMNS ...]]
           [--single-location SINGLE_LOCATION] [--stackers [STACKERS ...]] [--single-swap-locations [SINGLE_SWAP_LOCATIONS ...]]
           PLUGIN ...
vol: error: Please select a plugin to run (see 'vol --help' for options
```

Here is the optional dependencies listed on the `pyproject` file of vol3:
```
[project.optional-dependencies]
full = [
    "yara-python>=4.5.1,<5",
    "capstone>=5.0.3,<6",
    "pycryptodome>=3.21.0,<4",
    "leechcorepyc>=2.19.2,<3; sys_platform != 'darwin'",
    # https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst
    # 10.0.0 dropped support for Python3.7
    # 11.0.0 dropped support for Python3.8, which is still supported by Volatility3
    "pillow>=10.0.0,<11.0.0",
]
```

This PR add dependency injection into the pipx env of vol3.

# Related issues

N / A

# Point of attention

N / A
