### PR TITLE
feat(cloud): added 2 new tool + history for roadtx

### DIFF
--- a/sources/assets/shells/aliases.d/findmeaccess
+++ b/sources/assets/shells/aliases.d/findmeaccess
@@ -1,0 +1,1 @@
+alias findmeaccess.py='/opt/tools/FindMeAccess/venv/bin/python3 /opt/tools/FindMeAccess/findmeaccess.py'

--- a/sources/assets/shells/aliases.d/fzf
+++ b/sources/assets/shells/aliases.d/fzf
@@ -4,3 +4,4 @@ alias fzf-haiti-hashcat='(){ haiti -e $1 | fzf --ansi | grep -E -o " [0-9]*]" | 
 alias fzf-haiti-john='(){ haiti -e $1 | fzf --ansi | grep -E -o "JtR: .*]" | cut -d "]" -f 1 | cut -d " " -f 2 ;}'
 alias hcat='(){ if [ -f "$1" ]; then hashcat -m $(fzf-haiti-hashcat $(head -n 1 "$1")) "$1" $(fzf-wordlists) "${@:2}"; elif [ -n "$1" ]; then hashcat -m $(fzf-haiti-hashcat "$1") "$1" $(fzf-wordlists) "${@:2}"; fi ;}'
 alias hjohn='(){ if [ -f "$1" ]; then john --format=$(fzf-haiti-john $(head -n 1 "$1")) --wordlist=$(fzf-wordlists) "${@:2}" $1; elif [ -n "$1" ]; then echo "$1" | john --format=$(fzf-haiti-john "$1") --wordlist=$(fzf-wordlists) "${@:2}" /dev/stdin; fi ;}'
+alias fzf-az-cid='(){jq -r ".[] | .AppDisplayName + \" (\" + .AppId + \")\"" /opt/lists/MicrosoftApps.json | fzf --header="Choose an Entra client id" --bind="enter:execute(echo {} | sed -n \"s/.*(\(.*\))[^)]*$/\1/p\")+abort"}'

--- a/sources/assets/shells/aliases.d/pytune
+++ b/sources/assets/shells/aliases.d/pytune
@@ -1,0 +1,1 @@
+alias pytune.py='/opt/tools/pytune/venv/bin/python3 /opt/tools/pytune/pytune.py'

--- a/sources/assets/shells/history.d/findmeaccess
+++ b/sources/assets/shells/history.d/findmeaccess
@@ -1,0 +1,1 @@
+findmeaccess.py audit -u "$USERNAME" -p "$PASSWORD"

--- a/sources/assets/shells/history.d/pytune
+++ b/sources/assets/shells/history.d/pytune
@@ -1,0 +1,3 @@
+pytune.py entra_join -o Windows -d "$MACHINE_NAME" -f .roadtools_auth
+pytune.py enroll_intune -o Windows -d "$MACHINE_NAME" -f .roadtools_auth -c "$MACHINE_NAME_PFX"
+pytune.py checkin -o Windows -d "$MACHINE_NAME" -f .roadtools_auth -c "$MACHINE_NAME_PFX" -m "$MACHINE_NAME_MDM_PFX"

--- a/sources/assets/shells/history.d/roadtx
+++ b/sources/assets/shells/history.d/roadtx
@@ -1,0 +1,6 @@
+roadtx gettokens -u "$USER" -p "$PASSWORD" -c `fzf-az-cid` -r aadgraph -ua edge
+roadtx interactiveauth -u "$USER" -p "$PASSWORD" -c `fzf-az-cid` -r aadgraph -ua edge
+roadtx interactiveauth -u "$USER" -p "$PASSWORD" -c `fzf-az-cid` -r aadgraph -ua edge --force-mfa
+roadtx browserprtauth -u "$USER" -p "$PASSWORD" -c `fzf-az-cid` -r aadgraph -ua edge
+roadtx prt -u "$USER" -p "$PASSWORD" --pfx-pass "$PFX_PASS" --cert-pfx "$PFX_CERT"
+roadtx listaliases

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1274,10 +1274,11 @@ function install_roadrecon() {
 }
 
 function install_roadtx() {
-    # CODE-CHECK-WHITELIST=add-aliases,add-history
+    # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing roadtx"
     pipx install --system-site-packages roadtx
     add-test-command "roadtx --help"
+    add-history roadtx
     add-to-list "ROADtx,https://github.com/dirkjanm/ROADtools#roadtools-token-exchange-roadtx,ROADtools Token eXchange."
 }
 

--- a/sources/install/package_cloud.sh
+++ b/sources/install/package_cloud.sh
@@ -165,6 +165,44 @@ function install_pacu() {
     add-to-list "pacu,https://github.com/RhinoSecurityLabs/pacu,The AWS exploitation framework for testing the security of Amazon Web Services environments."
 }
 
+function install_pytune() {
+    colorecho "Installing pytune"
+    git -C /opt/tools clone --depth 1 https://github.com/secureworks/pytune.git
+    cd /opt/tools/pytune || exit
+    # Remove unecessary dependency
+    sed -i "s/colr//" requirements.txt
+    python3 -m venv --system-site-packages ./venv
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
+    add-test-command "pytune.py --help"
+    add-aliases pytune
+    add-history pytune
+    add-to-list "pytune,https://github.com/secureworks/pytune,Pytune is a post-exploitation tool for enrolling a fake device into Intune with mulitple platform support."
+}
+
+function install_findmeaccess() {
+    colorecho "Installing findmeaccess"
+    git -C /opt/tools clone --depth 1 https://github.com/absolomb/FindMeAccess
+    cd /opt/tools/FindMeAccess || exit
+    python3 -m venv --system-site-packages ./venv
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
+    add-test-command "findmeaccess.py --help"
+    add-aliases findmeaccess
+    add-history findmeaccess
+    add-to-list "findmeaccess,https://github.com/absolomb/FindMeAccess,FindMeAccess is a tool useful for finding gaps in Azure/M365 MFA requirements for different resources and client ids and user agents."
+}
+
+function install_merill_list() {
+    # CODE-CHECK-WHITELIST=add-aliases,add-history
+    colorecho "Installing merill list"
+    wget https://raw.githubusercontent.com/merill/microsoft-info/main/_info/MicrosoftApps.json -O /opt/lists/MicrosoftApps.json
+    add-test-command "[[ -f '/opt/lists/MicrosoftApps.json' ]]"
+    add-to-list "merill list,https://github.com/merill/microsoft-info,This repository provides an up-to-date list of Microsoft first party apps and Graph Permissions that can be easily consumed by scripts."
+}
+
 # Package dedicated to cloud tools
 function package_cloud() {
     set_env
@@ -182,6 +220,9 @@ function package_cloud() {
     install_azure_cli       # Command line for Azure
     install_s3scanner		# S3 buckets misconfiguration scanner
     install_pacu            # AWS exploitation framework
+    install_pytune
+    install_findmeaccess
+    install_merill_list
     post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))


### PR DESCRIPTION
# Description

Greetings,

This PR add two new tool related to Azure environment. One can be used to play with Intune compliancy check, the other can find bypass in CA / MFA by bruteforcing UA / CID / Resource combination.

This PR also add a wordlist for Microsoft Apps Client ID and an `fzf` alias to quickly select a client id during Azure engagment.

<img width="674" height="870" alt="image" src="https://github.com/user-attachments/assets/87155734-210b-4d0c-9798-48f754deccfa" />

The tool also add history for the great `roadtx` tool.

# Related issues

N/A

# Point of attention

N/A

Regards.