### PR TITLE
fix(john): fix pfx2john.py required package

### DIFF
--- a/sources/assets/shells/aliases.d/john-the-ripper
+++ b/sources/assets/shells/aliases.d/john-the-ripper
@@ -1,3 +1,3 @@
 alias john='/opt/tools/john/run/john'
-alias ssh2john='/opt/tools/john/run/ssh2john.py'
+alias ssh2john.py='/opt/tools/john/run/ssh2john.py'
 alias pfx2john.py='/opt/tools/john/run/venv/bin/python3 /opt/tools/john/run/pfx2john.py'

--- a/sources/assets/shells/aliases.d/john-the-ripper
+++ b/sources/assets/shells/aliases.d/john-the-ripper
@@ -1,2 +1,3 @@
 alias john='/opt/tools/john/run/john'
 alias ssh2john='/opt/tools/john/run/ssh2john.py'
+alias pfx2john.py='/opt/tools/john/run/venv/bin/python3 /opt/tools/john/run/pfx2john.py'

--- a/sources/install/package_cracking.sh
+++ b/sources/install/package_cracking.sh
@@ -30,6 +30,14 @@ function install_john() {
     cd /opt/tools/john/src || exit
     ./configure --disable-native-tests && make
     yes|cpan install Compress::Raw::Lzma
+
+    # Install required asn1crypto for pfx2john.py
+    cd /opt/tools/john/run/ || exit
+    python3 -m venv --system-site-packages ./venv
+    source ./venv/bin/activate
+    pip install asn1crypto
+    deactivate
+
     add-aliases john-the-ripper
     add-history john-the-ripper
     add-test-command "john --help"


### PR DESCRIPTION
# Description

Greetings,

Using `pfx2john.py` show an error saying: `asn1crypto is missing, run 'pip install --user asn1crypto' to install it!`, this PR aim to fix that by installing the package in a venv.

Regards.

# Related issues

N/A

# Point of attention

N/A
