### PR TITLE
fix(ad): Restore working directory after installing ntlmv1-multi

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -742,11 +742,12 @@ function install_gpp-decrypt() {
 function install_ntlmv1-multi() {
     colorecho "Installing ntlmv1 multi tool"
     git -C /opt/tools clone --depth 1 https://github.com/evilmog/ntlmv1-multi
-    cd /opt/tools/ntlmv1-multi || exit
+    pushd /opt/tools/ntlmv1-multi >/dev/null || exit
     python3 -m venv --system-site-packages ./venv
     source ./venv/bin/activate
     pip3 install pycryptodome
     deactivate
+    popd >/dev/null || exit
     add-aliases ntlmv1-multi
     add-history ntlmv1-multi
     add-test-command "ntlmv1-multi.py --ntlmv1 SV01$::DOMAIN.LOCAL:AD1235DEAC142CD5FC2D123ADCF51A111ADF45C2345ADCF5:AD1235DEAC142CD5FC2D123ADCF51A111ADF45C2345ADCF5:1122334455667788"


### PR DESCRIPTION
# Description

Hello Exegol,

While experimenting with adding a new tool to a local image, I ran into a couple of issues when building a **Full** image:

1. https://github.com/ihebski/DefaultCreds-cheat-sheet could no longer be installed with `pipx`, but I believe this has now been resolved: https://github.com/ihebski/DefaultCreds-cheat-sheet/pull/127

2. Installing https://github.com/ShutdownRepo/hashonymize failed with `pipx`:

```shell
pyenv: pipx: command not found

The `pipx` command exists in these Python versions:
  3.11.15
```

After investigating, it appears that this issue may have been introduced following the addition of a `.python-version` file to the upstream `ntlmv1-multi` repository.

The function changes the working directory (`cd /opt/tools/ntlmv1-multi`) but never restores the previous one. As a result, subsequent installation functions continue to execute in that directory, causing `pyenv` to select Python 3.14. Since `pipx` is installed under Python 3.11.15, the next installation (`hashonymize`) fails.

This PR simply addresses point 2.

I validated the fix locally by successfully building a **Full** image.

# Related issues

N/A

# Point of attention

- The issue only became apparent after a recent upstream change introducing a `.python-version` file in the `ntlmv1-multi` repository.
- Please feel free to adjust the implementation if you think there is a cleaner way to achieve the same result.