### PR TITLE
feat(ad): add RelayInformer

### DIFF
--- a/sources/assets/shells/history.d/relayinformer
+++ b/sources/assets/shells/history.d/relayinformer
@@ -1,0 +1,4 @@
+relayinformer ldap --method LDAPS --dc-ip "$DC_IP"
+relayinformer ldap --method BOTH --dns -u "$USER" -p "$PASSWORD" -d "$DOMAIN"
+relayinformer http --url "https://pki.$DOMAIN/certsrv" --user "$DOMAIN/$USER" --password "$PASSWORD"
+relayinformer http --url "http://pki.$DOMAIN/certsrv" --user "$DOMAIN\\$USER" --hashes LM:NT

--- a/sources/assets/shells/history.d/relayinformer
+++ b/sources/assets/shells/history.d/relayinformer
@@ -1,4 +1,6 @@
-relayinformer ldap --method LDAPS --dc-ip "$DC_IP"
-relayinformer ldap --method BOTH --dns -u "$USER" -p "$PASSWORD" -d "$DOMAIN"
 relayinformer http --url "https://pki.$DOMAIN/certsrv" --user "$DOMAIN/$USER" --password "$PASSWORD"
-relayinformer http --url "http://pki.$DOMAIN/certsrv" --user "$DOMAIN\\$USER" --hashes LM:NT
+relayinformer http --url "http://pki.$DOMAIN/certsrv" --user "$DOMAIN/$USER" --hashes :"$NT_HASH"
+relayinformer mssql --target "$TARGET" --user "$DOMAIN/$USER" --password "$PASSWORD"
+relayinformer mssql --target "$TARGET" --user "$DOMAIN/$USER" --hashes :"$NT_HASH"
+relayinformer ldap --method LDAPS --dc-ip "$DC_IP"
+relayinformer ldap --method BOTH --dc-ip "$DC_IP" --domain "$DOMAIN" --user "$USER" --password "$PASSWORD"

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1198,7 +1198,24 @@ function install_relayinformer() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing RelayInformer"
     git -C /opt/tools/ clone --depth 1 https://github.com/zyn3rgy/RelayInformer
-    pipx install --system-site-packages /opt/tools/RelayInformer/Python/
+    rm -rf /opt/tools/RelayInformer/BOF
+    cd /opt/tools/RelayInformer/Python || exit
+    python3 -m venv --system-site-packages ./venv
+    # Reuse the existing original Impacket installation instead of installing RelayInformer's pinned copy
+    relayinformer_site_packages="$(./venv/bin/python3 -c 'import sysconfig; print(sysconfig.get_path("purelib"))')"
+    echo "$(/opt/tools/impacket-og/venv/bin/python3 -c 'import site; print(site.getsitepackages()[0])')" \
+        > "${relayinformer_site_packages}/impacket-og.pth"
+    source ./venv/bin/activate
+    pip3 install --no-cache-dir --no-deps .
+    pip3 install --no-cache-dir typer msldap requests-ntlm
+    # Override the system oscrypto package that is incompatible with Exegol's OpenSSL setup
+    pip3 install --no-cache-dir --force-reinstall \
+        "oscrypto @ git+https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8"
+    pip3 uninstall -y pip setuptools wheel
+    deactivate
+    find ./venv -type d -name '__pycache__' -prune -exec rm -rf {} +
+    ln -v -s /opt/tools/RelayInformer/Python/venv/bin/relayinformer /opt/tools/bin/relayinformer
+    cd || exit
     add-history relayinformer
     add-test-command "relayinformer --help"
     add-to-list "RelayInformer,https://github.com/zyn3rgy/RelayInformer,Determine EPA enforcement levels of popular NTLM relay targets from a Linux host."
@@ -1755,7 +1772,6 @@ function package_ad() {
     install_msprobe
     install_masky
     install_roastinthemiddle
-    install_relayinformer           # Determine EPA enforcement levels of popular NTLM relay targets
     install_PassTheCert
     install_bqm                    # Deduplicate custom BloudHound queries from different datasets and merge them in one customqueries.json file.
     install_neo4j                  # Bloodhound dependency
@@ -1793,6 +1809,7 @@ function package_ad() {
     install_keytabextract          # Extract valuable information from keytab files
     install_daclsearch             # Exhaustive search and flexible filtering of Active Directory ACEs
     install_impacket_og            # Impacket scripts (original version)
+    install_relayinformer           # Determine EPA enforcement levels of popular NTLM relay targets
     install_bloodbash              # Bloodhound in terminal
     install_evenmonitor            # Monitor the Windows Event Log with grep-like features or filtering for specific Event IDs
     install_tdo_dump               # Dump trusted domain objects to extract trust credentials

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1192,6 +1192,16 @@ function install_roastinthemiddle() {
     add-to-list "roastinthemiddle,https://github.com/Tw1sm/RITM,RoastInTheMiddle is a tool to intercept and relay NTLM authentication requests."
 }
 
+function install_relayinformer() {
+    # CODE-CHECK-WHITELIST=add-aliases
+    colorecho "Installing RelayInformer"
+    git -C /opt/tools/ clone --depth 1 https://github.com/zyn3rgy/RelayInformer
+    pipx install --system-site-packages /opt/tools/RelayInformer/Python/
+    add-history relayinformer
+    add-test-command "relayinformer --help"
+    add-to-list "RelayInformer,https://github.com/zyn3rgy/RelayInformer,Determine EPA enforcement levels of popular NTLM relay targets from a Linux host."
+}
+
 function install_PassTheCert() {
     colorecho "Installing PassTheCert"
     git -C /opt/tools/ clone --depth 1 https://github.com/AlmondOffSec/PassTheCert
@@ -1743,6 +1753,7 @@ function package_ad() {
     install_msprobe
     install_masky
     install_roastinthemiddle
+    install_relayinformer           # Determine EPA enforcement levels of popular NTLM relay targets
     install_PassTheCert
     install_bqm                    # Deduplicate custom BloudHound queries from different datasets and merge them in one customqueries.json file.
     install_neo4j                  # Bloodhound dependency


### PR DESCRIPTION
# Description

Hello, this PR adds the [RelayInformer](https://github.com/zyn3rgy/RelayInformer) tool to the base image in the `ad` package. This tool checks EPA/CBT enforcement on different services subject to relaying, namely MSSQL/LDAP(S)/HTTP(S).

While there is some overlap here with various tools having implemented similar enumeration techniques for some protocols (`netexec` does have a few, but no HTTP(S) AFAIK), this is still [a reference tool](https://specterops.io/blog/2025/11/25/less-praying-more-relaying-enumerating-epa-enforcement-for-mssql-and-https/) that I think is worth having and that I still use often. 

# Related issues

N/A

# Point of attention

- Unrelated to `RelayInformer` itself, but I had to do my local tests with a container built with https://github.com/ThePorgs/Exegol-images/pull/713, or else it would get stuck at `hashonymize`. It seemed to work fine in local testing.
<img width="2102" height="184" alt="image" src="https://github.com/user-attachments/assets/7b40597a-24e2-40cb-8816-b9a19d46d245" />

- This is my first contribution, I tried to respect the docs and conventions but please let me know if something's wrong :)
