### PR TITLE
fix: pipx resolution failure in install_hashonymize

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -751,6 +751,8 @@ function install_ntlmv1-multi() {
     add-history ntlmv1-multi
     add-test-command "ntlmv1-multi.py --ntlmv1 SV01$::DOMAIN.LOCAL:AD1235DEAC142CD5FC2D123ADCF51A111ADF45C2345ADCF5:AD1235DEAC142CD5FC2D123ADCF51A111ADF45C2345ADCF5:1122334455667788"
     add-to-list "ntlmv1-multi,https://github.com/evilmog/ntlmv1-multi,Exploit a vulnerability in Microsoft Windows to gain system-level access."
+    # exit the ntlmv1-multi workdir, since it sets the python version to 3.14 and could mess up later installs
+    cd || exit
 }
 
 function install_hashonymize() {


### PR DESCRIPTION
# Description

Install_ntlmv1-multi cds into the cloned repo and never returns. That repo ships a .python-version file pinned to 3.14, which leaks into the next function in the call chain, install_hashonymize. Since pipx was only ever installed under the priority pyenv version (3.11.x), pyenv's shim fails with pipx: command not found, and the build image with the ad profile can't be built.
