### PR TITLE
feat(web): added tlsx,vulnx,mapcidr,urlfinder

### DIFF
--- a/sources/assets/shells/history.d/mapcidr
+++ b/sources/assets/shells/history.d/mapcidr
@@ -1,0 +1,1 @@
+mapcidr -cidr "$RANGE"

--- a/sources/assets/shells/history.d/tlsx
+++ b/sources/assets/shells/history.d/tlsx
@@ -1,0 +1,2 @@
+tlsx -u "$TARGET" -san -cn -silent
+tlsx -u "$TARGET" -expired -self-signed -mismatched -revoked -untrusted -tv

--- a/sources/assets/shells/history.d/urlfinder
+++ b/sources/assets/shells/history.d/urlfinder
@@ -1,0 +1,1 @@
+urlfinder -d "$TARGET"

--- a/sources/assets/shells/history.d/vulnx
+++ b/sources/assets/shells/history.d/vulnx
@@ -1,0 +1,2 @@
+vulnx search "apache"
+vulnx search --json "ServiceNow" | jq '.results[].pocs'

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -1072,6 +1072,46 @@ function install_xxeinjector() {
     add-to-list "XXEinjector,https://github.com/enjoiz/XXEinjector,A tool for XML External Entity (XXE) injection testing"
 }
 
+function install_tlsx() {
+    # CODE-CHECK-WHITELIST=add-aliases
+    colorecho "Installing tlsx"
+    go install -v github.com/projectdiscovery/tlsx/cmd/tlsx@latest
+    asdf reshim golang
+    add-history tlsx
+    add-test-command "tlsx --version"
+    add-to-list "tlsx,https://github.com/projectdiscovery/tlsx,A fast and configurable TLS grabber focused on TLS based data collection and analysis."
+}
+
+function install_vulnx() {
+    # CODE-CHECK-WHITELIST=add-aliases
+    colorecho "Installing vulnx"
+    go install -v github.com/projectdiscovery/vulnx/v2/cmd/vulnx@latest
+    asdf reshim golang
+    add-history vulnx
+    add-test-command "vulnx --help"
+    add-to-list "vulnx,https://github.com/projectdiscovery/vulnx,Modern CLI for exploring vulnerability data with powerful search filtering and analysis capabilities."
+}
+
+function install_urlfinder() {
+    # CODE-CHECK-WHITELIST=add-aliases
+    colorecho "Installing URLFinder"
+    go install -v github.com/projectdiscovery/urlfinder/cmd/urlfinder@latest
+    asdf reshim golang
+    add-history urlfinder
+    add-test-command "urlfinder --version"
+    add-to-list "urlfinder,https://github.com/projectdiscovery/urlfinder,URLFinder is a high-speed passive URL discovery tool designed to simplify and accelerate web asset discovery."
+}
+
+function install_mapcidr() {
+    # CODE-CHECK-WHITELIST=add-aliases
+    colorecho "Installing mapCIDR"
+    go install -v github.com/projectdiscovery/mapcidr/cmd/mapcidr@latest
+    asdf reshim golang
+    add-history mapcidr
+    add-test-command "mapcidr --version"
+    add-to-list "mapcidr,https://github.com/projectdiscovery/mapcidr,Utility program to perform multiple operations for a given subnet/CIDR ranges."
+}
+
 # Package dedicated to applicative and active web pentest tools
 function package_web() {
     set_env
@@ -1160,6 +1200,10 @@ function package_web() {
     install_urldedupe               # Get back a list of deduplicated (unique) URL and query string combination. 
     install_curlie                  # Mix of cURL and HTTPie
     install_xxeinjector             # XXE injection testing tool
+    install_tlsx
+    install_vulnx
+    install_urlfinder
+    install_mapcidr
     post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))


### PR DESCRIPTION
# Description

Greetings,

This PR aims to add multiple ProjectDiscovery tool for the web part of Exegol.

Regards.

# Related issues

N/A

# Point of attention

Urlfinder job is indeed already covered by the `gau` tool, however, in my humble opinion, ProjectDiscovery tools are well made and are meant work together (same options nomenclature, same output, etc...), especially in bug bounty scenario.
