### PR TITLE
feat(fzf): added fzf-if alias

### DIFF
--- a/sources/assets/shells/aliases.d/fzf
+++ b/sources/assets/shells/aliases.d/fzf
@@ -4,3 +4,4 @@ alias fzf-haiti-hashcat='(){ haiti -e $1 | fzf --ansi | grep -E -o " [0-9]*]" | 
 alias fzf-haiti-john='(){ haiti -e $1 | fzf --ansi | grep -E -o "JtR: .*]" | cut -d "]" -f 1 | cut -d " " -f 2 ;}'
 alias hcat='(){ if [ -f "$1" ]; then hashcat -m $(fzf-haiti-hashcat $(head -n 1 "$1")) "$1" $(fzf-wordlists) "${@:2}"; elif [ -n "$1" ]; then hashcat -m $(fzf-haiti-hashcat "$1") "$1" $(fzf-wordlists) "${@:2}"; fi ;}'
 alias hjohn='(){ if [ -f "$1" ]; then john --format=$(fzf-haiti-john $(head -n 1 "$1")) --wordlist=$(fzf-wordlists) "${@:2}" $1; elif [ -n "$1" ]; then echo "$1" | john --format=$(fzf-haiti-john "$1") --wordlist=$(fzf-wordlists) "${@:2}" /dev/stdin; fi ;}'
+alias fzf-if='ip --brief a | cut -d " " -f 1 | fzf'

--- a/sources/assets/shells/history.d/responder
+++ b/sources/assets/shells/history.d/responder
@@ -1,9 +1,9 @@
-Responder.py --interface "$INTERFACE" --analyze --lm --disable-ess
-Responder.py --interface "$INTERFACE" --analyze --disable-ess
-Responder.py --interface "$INTERFACE" --wpad --lm --disable-ess
-responder --interface "$INTERFACE" --analyze --lm --disable-ess
-responder --interface "$INTERFACE" --analyze --disable-ess
-responder --interface "$INTERFACE" --wpad --lm --disable-ess
+Responder.py --interface `fzf-if` --analyze --lm --disable-ess
+Responder.py --interface `fzf-if` --analyze --disable-ess
+Responder.py --interface `fzf-if` --wpad --lm --disable-ess
+responder --interface `fzf-if` --analyze --lm --disable-ess
+responder --interface `fzf-if` --analyze --disable-ess
+responder --interface `fzf-if` --wpad --lm --disable-ess
 responder-http-off
 responder-http-on
 responder-smb-off


### PR DESCRIPTION
# Description

Greetings,

This PR aims to add a small `fzf` alias to select a network interface interactively, this is made to avoid having to type network interface name everytime, for now it's only used for `responder` history entry, but if the team thinks this PR is interesting, I can replace all `$INTERFACE` variable by this alias.

Regards.

# Related issues

N/A

# Point of attention

N/A