### PR TITLE
fr: Replace Evil-winrpy with Pwnrm

### DIFF
--- a/sources/assets/shells/history.d/evil-winrm-py
+++ b/sources/assets/shells/history.d/evil-winrm-py
@@ -1,5 +1,0 @@
-evil-winrm-py --ip "$TARGET" --user "$USER" --password "$PASSWORD"
-evil-winrm-py --ip "$TARGET" --user "$USER" --password "$PASSWORD" --kerberos
-evil-winrm-py --ip "$TARGET" --user "$USER" --hash "$NT_HASH"
-evil-winrm-py --ip "$TARGET" --user "$USER" --kerberos --no-pass
-KRB5CCNAME="$CCACHE_PATH" evil-winrm-py --ip "$TARGET" --kerberos

--- a/sources/assets/shells/history.d/pwnrm
+++ b/sources/assets/shells/history.d/pwnrm
@@ -1,0 +1,5 @@
+pwnrm -u "$USER" -p "$PASSWORD" "$TARGET"
+pwnrm -u "$USER" -H "NT_HASH" "$TARGET"
+pwnrm -u "$USER"@"$DOMAIN" -k --ccache "/workspace/user.ccache" "$TARGET"
+pwnrm -u "$USER"@"$DOMAIN" --pfx admin.pfx --pfx-pass secret "$TARGET"
+pwnrm -u "$USER" -p "$PASSWORD" --credssp "$TARGET"

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1613,13 +1613,13 @@ function install_pygoldengmsa() {
     add-to-list "pygoldengmsa,https://github.com/felixbillieres/pyGoldenGMSA, Cross-platform Python implementation of the GoldenGMSA attack for exploiting Group Managed Service Accounts (gMSA) in Active Directory. "
 }
 
-function install_evil-winrm-py() {
+function install_pwnrm() {
     # CODE-CHECK-WHITELIST=add-aliases
-    colorecho "Installing evil-winrm-py"
-    pipx install --system-site-package 'evil-winrm-py[kerberos]@git+https://github.com/adityatelange/evil-winrm-py'
-    add-history evil-winrm-py
-    add-test-command "evil-winrm-py --help"
-    add-to-list "evil-winrm-py,https://github.com/adityatelange/evil-winrm-py,Evil-WinRM. But in python"
+    colorecho "Installing pwnrm"
+    pipx install --system-site-package 'git+https://github.com/uziii2208/PwnRM'
+    add-history pwnrm
+    add-test-command "pwnrm --help"
+    add-to-list "pwnrm,https://github.com/uziii2208/PwnRM,Evil-WinRM. But in python and more featured"
 }
 
 function install_keytabextract() {
@@ -1796,7 +1796,7 @@ function package_ad() {
     install_godap                  # A complete terminal user interface (TUI) for LDAP
     install_powerview              # Powerview Python implementation
     install_pysnaffler             # Snaffler, but in Python
-    install_evil-winrm-py          # Evil-Winrm, but in Python
+    install_pwnrm                  # Evil-Winrm, but in Python and more featured
     install_keytabextract          # Extract valuable information from keytab files
     install_daclsearch             # Exhaustive search and flexible filtering of Active Directory ACEs
     install_impacket_og            # Impacket scripts (original version)


### PR DESCRIPTION
# Description

This PR replace evil-winrm-py with pwnrm. A more featured Python WinRM client with some tooling integrated directly like keberos manipulation, adcs enumeration etc (the full list here : https://pwnrmsec.ai.studio/commands

# Related issues

N/A

# Point of attention

N/A

Cheers !
